### PR TITLE
release: v1.9.2 - 悬浮歌词改造 + 分 P 支持 + 我的收藏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+本文件记录说说播放器 v2 工作区的发布历史。版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)，格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/)。
+
+> 1.x 区间为 **Beta**；2.0+ 起进入稳定版。
+
+## [1.9.2] - 待发布
+
+### 新增
+
+- **悬浮歌词独立开关与样式自定义**：footer 上方的当前歌词条重塑为可配置的"悬浮歌词"模块，与全屏歌词页解耦。
+  - 右下角 Music 按钮改为 `Captions` 图标，控制悬浮歌词的显示/隐藏，状态持久化
+  - 抽出 `FloatingLyrics` 子组件；配置项扩展至 `PlayerProfile.floatingLyrics` 子对象（8 字段：启用 / 字号 / 字重 / 字体族 / 对齐 / 垂直偏移 / 文字色 / 不透明度）
+  - 设置 → 外观新增「悬浮歌词」Card：包含开关、字号 12-32 滑块、字重 / 字体族 / 对齐按钮组、垂直偏移 16-64 px 滑块、4 预设文字色（跟随主色 / 白 / 黑 / 次要文字）、整体不透明度 0-100%、实时预览（复用真组件）、恢复默认
+  - 持久化老用户兼容：`ui_profile` hydrate 时 spread `DEFAULT_FLOATING_LYRICS` 兜底，缺字段不会崩
+- **多 P 投稿分 P 选择器支持多选加歌单**：可一次性把多个 P 加入歌单；多 P 条目在播放队列 / 歌单中的显示与写入语义统一
+- **B 站投稿分 P 支持**：多 P 视频可选择具体分 P 播放，UI 提供 P 选择器 Popover；持久化用户上次选的 P
+- **「我的收藏」系统级歌单**：左下角收藏按钮可一键加入；左侧栏 UI 重排
+- **VideoItem 交互升级**：双击 / 封面单击直接播放，右侧按钮改为收藏占位（解决误触播放问题）
+
+### 变更
+
+- 左下角播放器封面成为**唯一**全屏歌词入口；hover 时显示 `Expand` 图标 + 50% 黑色蒙层提示
+- 悬浮歌词定位改用 `bottom: 100% + transform: translateY(-Npx)` 二段定位，规避 grid + overflow 嵌套场景下 `calc(100% + Npx)` 可能失效的问题
+
+### 修复
+
+- 修复快速切歌时旧曲目 `Howl` 实例未及时 unload 导致的**双音频并发播放**竞态
+- 收藏夹歌单页若干显示问题；`FavCard` 体验优化
+
+### 内部
+
+- 持久化注册表 `STORE_PERSIST_REGISTRY` 中 `ui_profile` hydrate 升级为显式合并 default，避免新增字段对老数据的破坏
+- 新增 `floating-lyrics.test.tsx`、补强 `player-profile.test.ts` / `persist.test.ts` / `appearance.test.tsx` 用例覆盖
+- 测试规模：shared 431 + web 489 + desktop 73 = **993 用例**全过；Chrome 扩展产物 1339 KiB（10240 预算的 13%）
+
+## [1.9.1] - 2026-05-10
+
+详见 GitHub Releases：<https://github.com/LanceLRQ/shuoshuo-player/releases/tag/v1.9.1>
+
+## 历史版本
+
+更早版本仅在 GitHub Releases 中记录，未维护本文件。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,78 @@
 - 新增 `floating-lyrics.test.tsx`、补强 `player-profile.test.ts` / `persist.test.ts` / `appearance.test.tsx` 用例覆盖
 - 测试规模：shared 431 + web 489 + desktop 73 = **993 用例**全过；Chrome 扩展产物 1339 KiB（10240 预算的 13%）
 
-## [1.9.1] - 2026-05-10
+## [1.9.1] - 2026-05-11
 
-详见 GitHub Releases：<https://github.com/LanceLRQ/shuoshuo-player/releases/tag/v1.9.1>
+### 新增
+
+- **启动检查更新 + 顶部通知 + 设置页「关于」**：客户端启动时拉取最新版本信息，发现新版在 TopBar 显示通知；设置页「关于」展示版本号、更新通道、镜像链接、协议与项目简介
+- **跨平台 HTTP 抽象 `PlatformBridge.http`**：shared 包新增版本比较工具 + update API；Chrome 扩展 / Tauri / Web 三端各自实现 http adapter 与权限声明
+- **关于页布局优化**：Chrome 扩展专属商店入口；项目简介、协议与开发者链接
+- **Windows portable 版**（v1.9.1 Windows）：单文件可执行 + 哨兵触发 + 数据同目录 + 静态 CRT 编译；正式 portable 支持 `--debug` 运行时开启 DevTools；新增 `build:portable:dev` 调试包（DevTools 自启 + 控制台日志可见）
+- **网络故障兜底**：`fetchMusicUrl` 增加重试机制、错误分类、跨平台文件日志
+
+### 变更
+
+- `scripts/deploy.sh` 重命名为 `scripts/release.sh`，避开 pnpm 内置 `pnpm deploy` 子命令冲突
+- `build:portable` 改用 Tauri v2 的 `--no-bundle`（旧 `--bundles none` 在 v2 已被 msi/nsis 强校验阻断）
+- README 镜像 URL 提示拆为「指定版本」与「latest」两种结构；安装区块新增国内镜像入口
+
+### 修复
+
+- 修复 Windows WebView2 音频代理：改用 http 映射而非自定义 URI scheme（自定义 scheme 在 WebView2 下被拦截）
+- 修复播放栏滚动、弹窗溢出、banner 切换三处 UI 缺陷
+
+### CI / 发版
+
+- 一键发版脚本：交互式输入版本 → `pnpm version:sync` 同步 7 处 → 提交 + tag + push → 触发 release.yml
+- `publish-release` job 生成 `version.json`（update-checker 客户端拉取的 manifest）+ README 一行说明
+- 移除 Linux 桌面端矩阵，桌面端产物仅出 **macOS ARM64** + **Windows x64**
+
+## [1.9.0] - 2026-05-09
+
+> v2 重构后首个 Beta 发布版本（标签 `v1.9.0-rc.1`），1.x 区间整体为 Beta 通道。
+
+### 新增
+
+- **「水晶蟹小屋」云服务模块**：原 cloud-services 更名为水晶蟹小屋，登录入口下沉到模块着陆页；着陆页视觉与交互打磨
+- **B 站退出登录功能**：恢复 v1 中的退出登录交互；Tauri 端 WebView Cookie 残留问题修复
+- **数据导入导出升级**：导出加 `version` 标识；导入支持版本识别、v1 迁移、三态合并（skip / replace / merge）
+- **搜索发现页能力扩展**：批量选择 → 复选框模式批量入歌单；搜索结果改用分页器并放开硬上限到 B 站官方 1000 条 / 50 页；显示 UP 主图标并新增排序下拉
+- **歌单卡片头像差异化**：自定义歌单 → 首张视频封面 + 首字渐变兜底；B 站收藏夹歌单头像也走相同兜底；UPLOADER 类型同步
+- **收藏夹编辑对话框对齐 v1**：类型置顶；BILI_FAV 类型可下拉选择收藏夹列表；自动命名
+- **Chrome 扩展加白 mountaintoys.cn**：支持音乐合作伙伴版权曲播放
+- **顶栏与导入对话框显示 Beta 徽章**：明示 1.x 为 Beta 通道
+- **全平台图标更换**：macOS Dock 显示中文名「说说播放器」
+
+### 变更
+
+- 顶栏导出改为统一走 `objectToDownload` 跨平台路由；移除下拉菜单中的主题模式区块（已迁移到设置页）
+- 导入对话框合并模式收紧为 `skip / replace` + UI 紧凑化
+- README 重构 + 新增 CONTRIBUTING（中英双语）；特性文案改为用户视角表述
+
+### 修复
+
+- 修复 Tauri 端老视频无法播放：content-type 规范化 + CORS 头补全 + 音质降级 fallback
+- 修复 mountaintoys.cn 第三方源接入 Tauri 代理（端口剥离）
+- 修复自定义歌单导入后显示为空：把 `bili_videos` 纳入导入并按 union 模式合并
+- 修复 UPLOADER / BILI_FAV 顶部播放按钮永远 disabled；按钮改 outline 视觉
+- 修复 `bili-user-videos` 重入：store action 入口加 `isLoading` 防重入
+- 修复播放队列列表项截断、清空按钮重叠等若干视觉缺陷
+- 修复 desktop `__DEV_LOG__` 按 vite mode 切换（恢复 dev 模式调试日志可见性）
+
+### 性能
+
+- 切歌冷启动延迟减少 1-2 秒（`fetchMusicUrl` 链路重排）
+- 音频代理 chunk 大小 4 MB → 16 MB，覆盖 5 分钟内主流码率单 chunk 命中
+- 音频缓存加密 AES-128-CBC → **ChaCha20**：dev 模式下 chunk 解码从 ~1 s 降到 ~10 ms
+- 未缓存歌曲首块响应延迟降低 ~60 ms
+
+### 内部 / CI
+
+- 引入**版本单源同步**：根 `package.json` 为单源，`pnpm version:sync` 同步到 7 处（manifest / Cargo.toml / tauri.conf.json 等）
+- 扩展打包脚本规范化：产物体积上限 10240 KiB
+- 拆分 `ci.yml`：PR 跑 lint/typecheck/test，tag 触发 Release 流程
 
 ## 历史版本
 
-更早版本仅在 GitHub Releases 中记录，未维护本文件。
+更早版本（v1.8.x 及之前）仅在 GitHub Releases 中记录，未维护本文件。

--- a/packages/desktop/src-tauri/src/commands/mod.rs
+++ b/packages/desktop/src-tauri/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod file;
 pub mod log;
 pub mod spider;
 pub mod store;
+pub mod window;

--- a/packages/desktop/src-tauri/src/commands/window.rs
+++ b/packages/desktop/src-tauri/src/commands/window.rs
@@ -1,0 +1,25 @@
+use tauri::{AppHandle, Manager, Theme};
+
+/// 设置主窗口的原生外观主题（macOS NSAppearance / Windows immersive dark mode）。
+///
+/// 必要性：Tauri v2 的 `WebviewWindow.setTheme()` JS 端 API 在 macOS 上是 NOOP，
+/// 仅影响 webview 的 prefers-color-scheme。要同步改变 macOS 系统标题栏文字色
+/// （在 `titleBarStyle: "Overlay"` 模式下尤其关键），必须在 Rust 端调用
+/// `Window::set_theme()`，由 Tauri 内部走 NSWindow.appearance API。
+///
+/// 入参：
+/// - "light" → 强制亮色
+/// - "dark"  → 强制暗色
+/// - 其他（含 "auto" / 空字符串）→ 跟随系统偏好（传 None）
+#[tauri::command]
+pub fn set_window_theme(app: AppHandle, theme: Option<String>) -> Result<(), String> {
+    let window = app.get_webview_window("main").ok_or("主窗口未找到")?;
+    let theme_enum = match theme.as_deref() {
+        Some("light") => Some(Theme::Light),
+        Some("dark") => Some(Theme::Dark),
+        _ => None,
+    };
+    window
+        .set_theme(theme_enum)
+        .map_err(|e| format!("set_theme 失败：{}", e))
+}

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             commands::log::log_clear,
             commands::log::log_get_dir,
             commands::log::log_open_dir,
+            commands::window::set_window_theme,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -19,7 +19,8 @@
         "minWidth": 960,
         "minHeight": 600,
         "decorations": true,
-        "resizable": true
+        "resizable": true,
+        "titleBarStyle": "Overlay"
       }
     ],
     "security": {

--- a/packages/desktop/src/lib/window-theme-sync.test.ts
+++ b/packages/desktop/src/lib/window-theme-sync.test.ts
@@ -1,0 +1,69 @@
+/**
+ * startWindowThemeSync 单测
+ *
+ * 验证：应用主题 → Tauri invoke('set_window_theme') 的同步契约。
+ * 实际 NSWindow.appearance 切换由 Rust 端 cargo + macOS runtime 行为承担。
+ */
+
+const mockInvoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+import { usePlayerProfileStore } from '@shuoshuo-player/shared';
+import { startWindowThemeSync } from './window-theme-sync';
+
+describe('startWindowThemeSync', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue(undefined);
+    usePlayerProfileStore.setState({ theme: 'auto' });
+  });
+
+  it('启动时立即同步当前 theme（auto → null）', () => {
+    startWindowThemeSync();
+    expect(mockInvoke).toHaveBeenCalledWith('set_window_theme', { theme: null });
+  });
+
+  it('启动时若 theme=light，传 "light"', () => {
+    usePlayerProfileStore.setState({ theme: 'light' });
+    startWindowThemeSync();
+    expect(mockInvoke).toHaveBeenCalledWith('set_window_theme', { theme: 'light' });
+  });
+
+  it('启动时若 theme=dark，传 "dark"', () => {
+    usePlayerProfileStore.setState({ theme: 'dark' });
+    startWindowThemeSync();
+    expect(mockInvoke).toHaveBeenCalledWith('set_window_theme', { theme: 'dark' });
+  });
+
+  it('订阅 store：theme 变化时再次 invoke', () => {
+    startWindowThemeSync();
+    mockInvoke.mockClear();
+    usePlayerProfileStore.setState({ theme: 'dark' });
+    expect(mockInvoke).toHaveBeenCalledWith('set_window_theme', { theme: 'dark' });
+  });
+
+  it('订阅 store：theme 未变（无关字段更新）不重复 invoke', () => {
+    usePlayerProfileStore.setState({ theme: 'light' });
+    startWindowThemeSync();
+    mockInvoke.mockClear();
+    // 改一个无关字段
+    usePlayerProfileStore.setState({ volume: 0.5 });
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('invoke 失败时仅 console.warn，不抛错', async () => {
+    mockInvoke.mockRejectedValueOnce(new Error('boom'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(() => startWindowThemeSync()).not.toThrow();
+      // 等待 microtask 让 Promise rejection 走完 .catch
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/desktop/src/lib/window-theme-sync.ts
+++ b/packages/desktop/src/lib/window-theme-sync.ts
@@ -1,0 +1,34 @@
+import { invoke } from '@tauri-apps/api/core';
+import { usePlayerProfileStore } from '@shuoshuo-player/shared';
+
+/**
+ * 同步应用 PlayerProfile.theme 到 Tauri 原生窗口外观（NSWindow.appearance / Windows immersive）。
+ *
+ * 必要性：Tauri v2 的 webview `setTheme()` 在 macOS 上是 NOOP，仅影响 webview
+ * 的 prefers-color-scheme，**不会改变 macOS 系统标题栏文字颜色**。在
+ * `titleBarStyle: "Overlay"` 模式下，标题文字色会变得与 shell 背景极难分辨。
+ * 必须走 Rust 端的 `Window::set_theme()` 调用 NSWindow API 才能生效。
+ *
+ * 触发：
+ * - 启动时一次（与持久化恢复后的 theme 对齐）
+ * - PlayerProfile.theme 变化时（设置 → 外观切换）
+ *
+ * theme=auto → 传 null 让 Tauri 跟随系统偏好；setTheme 调用幂等。
+ */
+export function startWindowThemeSync(): void {
+  let lastTheme: 'light' | 'dark' | 'auto' | null = null;
+
+  const apply = (): void => {
+    const theme = usePlayerProfileStore.getState().theme;
+    if (theme === lastTheme) return;
+    lastTheme = theme;
+    const payload = theme === 'auto' ? null : theme;
+    void invoke('set_window_theme', { theme: payload }).catch((err) => {
+      // 单次失败不阻塞应用启动；记录便于排查
+      console.warn('[window-theme-sync] set_window_theme failed:', err);
+    });
+  };
+
+  apply();
+  usePlayerProfileStore.subscribe(apply);
+}

--- a/packages/desktop/src/main.tsx
+++ b/packages/desktop/src/main.tsx
@@ -14,6 +14,7 @@ import {
   createTauriBilibiliHttpAdapter,
   createTauriCloudHttpAdapter,
 } from '@desktop/lib/tauri-bilibili-http-adapter';
+import { startWindowThemeSync } from '@desktop/lib/window-theme-sync';
 import '@/styles/globals.css';
 
 // 启动期 nav 接口若长时间未响应（极端网络场景），UI 不应永久卡在 spinner；
@@ -39,6 +40,10 @@ bootstrapPersistence()
     console.error('[shuoshuo-desktop] bootstrap 失败，使用空状态启动：', err);
   })
   .finally(() => {
+    // 应用主题 → 原生窗口外观同步（必须在 bootstrapPersistence 之后，
+    // 才能读到持久化后的 theme 值；订阅延后注册避免启动期重复触发）
+    startWindowThemeSync();
+
     // Wbi 密钥仅在启动时拉一次（与 v1 player.js mount-once 行为一致）；
     // wbi key 每日更新，单次会话内无需周期刷新——多次 nav 反而可能触发 B 站风控
     void triggerWbiRefresh().catch(() => {

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -13,6 +13,7 @@ export const PERSIST_KEYS = [
   'cloud_service',
   'music_url_cache',
   'update_checker',
+  'favorites',
 ] as const;
 
 /** 可导出的 store key（cloud_service 出于安全不导出） */
@@ -23,6 +24,7 @@ export const EXPORT_KEYS = [
   'fav_list',
   'ui_profile',
   'lyrics',
+  'favorites',
 ] as const;
 
 /** 主 UP 主信息 */

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -14,6 +14,7 @@ export const PERSIST_KEYS = [
   'music_url_cache',
   'update_checker',
   'favorites',
+  'video_page_pref',
 ] as const;
 
 /** 可导出的 store key（cloud_service 出于安全不导出） */
@@ -25,6 +26,7 @@ export const EXPORT_KEYS = [
   'ui_profile',
   'lyrics',
   'favorites',
+  'video_page_pref',
 ] as const;
 
 /** 主 UP 主信息 */

--- a/packages/shared/src/store/fav-list.test.ts
+++ b/packages/shared/src/store/fav-list.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useFavListStore } from './fav-list';
+import { useBilibiliUserVideosStore } from './bilibili-user-videos';
 import { FavListType } from '../types';
 
 function makeFav(type: FavListType, mid?: string) {
@@ -90,6 +91,63 @@ describe('useFavListStore（E1/E2 TrackId 校验）', () => {
       useFavListStore.getState().removeFavVideo(fav.id, 'BV1aB4y1k7Yx:p2');
       const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
       expect(after?.bv_ids).toEqual(['BV1aB4y1k7Yx']);
+    });
+  });
+
+  describe('addFavVideoByBvids（多 P 批量回归）', () => {
+    it('同 bvid 的多 P TrackId：view 接口仅调一次，全部 P 都写入歌单', async () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      const getVideoByBvid = vi.fn(async () => true);
+      useBilibiliUserVideosStore.setState({ getVideoByBvid });
+
+      const result = await useFavListStore
+        .getState()
+        .addFavVideoByBvids(fav.id, [
+          'BV1aB4y1k7Yx',
+          'BV1aB4y1k7Yx:p2',
+          'BV1aB4y1k7Yx:p3',
+          'BV1aB4y1k7Yx:p4',
+        ]);
+
+      // bug 修复关键断言：view 调用 1 次而非 4 次（避免限流后只有首条成功）
+      expect(getVideoByBvid).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(4);
+      expect(result.failed).toBe(0);
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual([
+        'BV1aB4y1k7Yx',
+        'BV1aB4y1k7Yx:p2',
+        'BV1aB4y1k7Yx:p3',
+        'BV1aB4y1k7Yx:p4',
+      ]);
+    });
+
+    it('view 接口失败时该 bvid 的所有 P 都计 failed', async () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useBilibiliUserVideosStore.setState({ getVideoByBvid: vi.fn(async () => false) });
+
+      const result = await useFavListStore
+        .getState()
+        .addFavVideoByBvids(fav.id, ['BV1Fail', 'BV1Fail:p2', 'BV1Fail:p3']);
+
+      expect(result.success).toBe(0);
+      expect(result.failed).toBe(3);
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual([]);
+    });
+
+    it('混合多个 bvid：每个 bvid 仅 view 1 次，所有 trackId 各自写入', async () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      const getVideoByBvid = vi.fn(async () => true);
+      useBilibiliUserVideosStore.setState({ getVideoByBvid });
+
+      await useFavListStore
+        .getState()
+        .addFavVideoByBvids(fav.id, ['BV1A', 'BV1A:p2', 'BV1B', 'BV1B:p3']);
+
+      expect(getVideoByBvid).toHaveBeenCalledTimes(2);
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual(['BV1A', 'BV1A:p2', 'BV1B', 'BV1B:p3']);
     });
   });
 });

--- a/packages/shared/src/store/fav-list.test.ts
+++ b/packages/shared/src/store/fav-list.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFavListStore } from './fav-list';
+import { FavListType } from '../types';
+
+function makeFav(type: FavListType, mid?: string) {
+  return useFavListStore.getState().addFavList({
+    name: 'test',
+    type,
+    bv_ids: [],
+    ...(mid ? { mid } : {}),
+  })!;
+}
+
+describe('useFavListStore（E1/E2 TrackId 校验）', () => {
+  beforeEach(() => {
+    useFavListStore.setState({ list: [] });
+  });
+
+  describe('addFavVideo', () => {
+    it('CUSTOM 接受纯 bvid', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual(['BV1aB4y1k7Yx']);
+    });
+
+    it('CUSTOM 接受合法 bvid:p<n>', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx:p3');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual(['BV1aB4y1k7Yx:p3']);
+    });
+
+    it('CUSTOM 拒绝非法 TrackId（如 av 格式 / 杂字符串）', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore.getState().addFavVideo(fav.id, 'av12345');
+      useFavListStore.getState().addFavVideo(fav.id, 'garbage');
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx:p1');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual([]);
+    });
+
+    it('UPLOADER 类型永远不写入（已有 type 检查兜底）', () => {
+      const fav = makeFav(FavListType.UPLOADER, '100001');
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual([]);
+    });
+
+    it('同 trackId 不重复', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx');
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual(['BV1aB4y1k7Yx']);
+    });
+
+    it('bvid 与 bvid:p<n> 视为不同 TrackId 并存', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx');
+      useFavListStore.getState().addFavVideo(fav.id, 'BV1aB4y1k7Yx:p2');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual(['BV1aB4y1k7Yx', 'BV1aB4y1k7Yx:p2']);
+    });
+  });
+
+  describe('batchAddFavVideos', () => {
+    it('CUSTOM 过滤非法 TrackId，保留合法 trackId', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore
+        .getState()
+        .batchAddFavVideos(fav.id, ['BV1', 'BV2:p3', 'av99', 'BV3:p1', 'BV4']);
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      // 'av99' 非 BV 前缀拒绝；'BV3:p1' 冗余表达拒绝
+      expect(after?.bv_ids).toEqual(['BV1', 'BV2:p3', 'BV4']);
+    });
+
+    it('UPLOADER 类型 batch 入参全部被忽略', () => {
+      const fav = makeFav(FavListType.UPLOADER, '100001');
+      useFavListStore.getState().batchAddFavVideos(fav.id, ['BV1', 'BV2']);
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual([]);
+    });
+  });
+
+  describe('removeFavVideo', () => {
+    it('删除 TrackId 条目（纯 bvid 与 :p<n> 视为不同 key）', () => {
+      const fav = makeFav(FavListType.CUSTOM);
+      useFavListStore.getState().batchAddFavVideos(fav.id, ['BV1aB4y1k7Yx', 'BV1aB4y1k7Yx:p2']);
+      useFavListStore.getState().removeFavVideo(fav.id, 'BV1aB4y1k7Yx:p2');
+      const after = useFavListStore.getState().list.find((f) => f.id === fav.id);
+      expect(after?.bv_ids).toEqual(['BV1aB4y1k7Yx']);
+    });
+  });
+});

--- a/packages/shared/src/store/fav-list.ts
+++ b/packages/shared/src/store/fav-list.ts
@@ -1,10 +1,31 @@
 import { create } from 'zustand';
 import { nanoid } from 'nanoid';
 import { FavListType, type FavListItem } from '../types';
-import { timeStampNow } from '../utils';
+import { timeStampNow, parseTrackId, trackIdToBvid, logger } from '../utils';
 import { MASTER_UP_INFO, NoticeType } from '../constants';
 import { useBilibiliUserVideosStore } from './bilibili-user-videos';
 import { useUIStore } from './ui';
+
+/**
+ * 校验单条 TrackId 写入是否合法（§2 列表语义边界 Phase E）：
+ *
+ * - UPLOADER / BILI_FAV：bv_ids 永远是纯 bvid，禁止任何 :p<n> 形式 → 拒绝写入
+ * - CUSTOM：接受纯 bvid 或 bvid:p<n>，但要求 TrackId 形式合法
+ *
+ * 返回 true 视为可写入；false 则调用方静默忽略（带 debug log）。
+ */
+function isWritableTrackId(trackId: string, type: FavListType): boolean {
+  const parsed = parseTrackId(trackId);
+  if (!parsed) {
+    logger.debug('[FAV-LIST]', 'reject malformed trackId', { trackId, type });
+    return false;
+  }
+  if (type !== FavListType.CUSTOM && parsed.page !== undefined) {
+    logger.warn('[FAV-LIST]', 'reject :p<n> trackId on non-CUSTOM fav', { trackId, type });
+    return false;
+  }
+  return true;
+}
 
 interface FavListState {
   list: FavListItem[];
@@ -12,14 +33,15 @@ interface FavListState {
   addFavList: (item: Omit<FavListItem, 'id' | 'create_time' | 'update_time'>) => FavListItem | null;
   removeFavList: (id: string) => void;
   modFavList: (id: string, name: string) => void;
-  addFavVideo: (favId: string, bvId: string) => void;
-  removeFavVideo: (favId: string, bvId: string) => void;
-  /** 批量添加（仅写入，不拉取视频信息；用于 import） */
-  batchAddFavVideos: (favId: string, bvIds: string[]) => void;
-  /** v1 addFavVideoByBvids：循环拉取视频信息 + 进度通知 */
+  /** 添加单条 TrackId（纯 bvid 或 bvid:p&lt;n&gt;）到 CUSTOM 歌单 */
+  addFavVideo: (favId: string, trackId: string) => void;
+  removeFavVideo: (favId: string, trackId: string) => void;
+  /** 批量添加 TrackId 到 CUSTOM 歌单（仅写入，不拉取视频信息；用于 import） */
+  batchAddFavVideos: (favId: string, trackIds: string[]) => void;
+  /** v1 addFavVideoByBvids：循环拉取视频信息（按 trackId 剥离的 bvid）+ 进度通知 */
   addFavVideoByBvids: (
     favId: string,
-    bvIds: string[],
+    trackIds: string[],
   ) => Promise<{ success: number; failed: number }>;
 }
 
@@ -53,36 +75,40 @@ export const useFavListStore = create<FavListState>((set, get) => ({
       ),
     })),
 
-  addFavVideo: (favId, bvId) =>
+  addFavVideo: (favId, trackId) =>
     set((state) => ({
       list: state.list.map((item) => {
         if (item.id !== favId || item.type !== FavListType.CUSTOM) return item;
-        if (item.bv_ids.includes(bvId)) return item;
+        // §2 校验：CUSTOM 只接受合法 TrackId（纯 bvid 或 bvid:p<n>）
+        if (!isWritableTrackId(trackId, item.type)) return item;
+        if (item.bv_ids.includes(trackId)) return item;
         return {
           ...item,
-          bv_ids: [...item.bv_ids, bvId],
+          bv_ids: [...item.bv_ids, trackId],
           update_time: timeStampNow(),
         };
       }),
     })),
 
-  removeFavVideo: (favId, bvId) =>
+  removeFavVideo: (favId, trackId) =>
     set((state) => ({
       list: state.list.map((item) => {
         if (item.id !== favId || item.type === FavListType.UPLOADER) return item;
         return {
           ...item,
-          bv_ids: item.bv_ids.filter((id) => id !== bvId),
+          bv_ids: item.bv_ids.filter((id) => id !== trackId),
           update_time: timeStampNow(),
         };
       }),
     })),
 
-  batchAddFavVideos: (favId, bvIds) =>
+  batchAddFavVideos: (favId, trackIds) =>
     set((state) => ({
       list: state.list.map((item) => {
         if (item.id !== favId || item.type !== FavListType.CUSTOM) return item;
-        const newIds = bvIds.filter((id) => !item.bv_ids.includes(id));
+        // §2 校验：过滤非法 TrackId（保留纯 bvid 与合法 bvid:p<n>）
+        const filtered = trackIds.filter((id) => isWritableTrackId(id, item.type));
+        const newIds = filtered.filter((id) => !item.bv_ids.includes(id));
         return {
           ...item,
           bv_ids: [...item.bv_ids, ...newIds],
@@ -91,16 +117,18 @@ export const useFavListStore = create<FavListState>((set, get) => ({
       }),
     })),
 
-  addFavVideoByBvids: async (favId, bvIds) => {
+  addFavVideoByBvids: async (favId, trackIds) => {
     const ui = useUIStore.getState();
     const userVideos = useBilibiliUserVideosStore.getState();
     let success = 0;
     let failed = 0;
-    for (let i = 0; i < bvIds.length; i++) {
-      const bvId = bvIds[i];
-      const ok = await userVideos.getVideoByBvid(bvId, i + 1, bvIds.length);
+    for (let i = 0; i < trackIds.length; i++) {
+      const trackId = trackIds[i];
+      // B 站 view 接口只接受纯 bvid；trackId 含 :p<n> 时先剥离再调用
+      const bvId = trackIdToBvid(trackId);
+      const ok = await userVideos.getVideoByBvid(bvId, i + 1, trackIds.length);
       if (ok) {
-        get().addFavVideo(favId, bvId);
+        get().addFavVideo(favId, trackId);
         success++;
       } else {
         failed++;

--- a/packages/shared/src/store/fav-list.ts
+++ b/packages/shared/src/store/fav-list.ts
@@ -120,14 +120,22 @@ export const useFavListStore = create<FavListState>((set, get) => ({
   addFavVideoByBvids: async (favId, trackIds) => {
     const ui = useUIStore.getState();
     const userVideos = useBilibiliUserVideosStore.getState();
+    // 按 bvid 去重 view 调用：多 P 投稿 N 个 P 共享同一 view 结果。
+    // 此前每 P 各调一次 view，B 站对同 bvid 高频 view 易触发限流 → 仅首次成功、后续 failed，
+    // 导致用户选 N 个 P 实际只入库 1 条。
+    const uniqueBvids = Array.from(new Set(trackIds.map(trackIdToBvid)));
+    const viewResults = new Map<string, boolean>();
+    for (let i = 0; i < uniqueBvids.length; i++) {
+      const bvId = uniqueBvids[i];
+      const ok = await userVideos.getVideoByBvid(bvId, i + 1, uniqueBvids.length);
+      viewResults.set(bvId, ok);
+    }
+
     let success = 0;
     let failed = 0;
-    for (let i = 0; i < trackIds.length; i++) {
-      const trackId = trackIds[i];
-      // B 站 view 接口只接受纯 bvid；trackId 含 :p<n> 时先剥离再调用
+    for (const trackId of trackIds) {
       const bvId = trackIdToBvid(trackId);
-      const ok = await userVideos.getVideoByBvid(bvId, i + 1, trackIds.length);
-      if (ok) {
+      if (viewResults.get(bvId)) {
         get().addFavVideo(favId, trackId);
         success++;
       } else {

--- a/packages/shared/src/store/favorites.test.ts
+++ b/packages/shared/src/store/favorites.test.ts
@@ -1,0 +1,82 @@
+import { useFavoritesStore, selectSortedBvids } from './favorites';
+
+function reset() {
+  useFavoritesStore.setState({ entries: {} });
+}
+
+describe('useFavoritesStore', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('初始 entries 为空对象', () => {
+    expect(useFavoritesStore.getState().entries).toEqual({});
+  });
+
+  it('toggle：未收藏 → 添加（写入时间戳），返回 true', () => {
+    const result = useFavoritesStore.getState().toggle('BV1');
+    expect(result).toBe(true);
+    const ts = useFavoritesStore.getState().entries.BV1;
+    expect(typeof ts).toBe('number');
+    expect(ts).toBeGreaterThan(0);
+  });
+
+  it('toggle：已收藏 → 移除，返回 false', () => {
+    useFavoritesStore.getState().add('BV1');
+    const result = useFavoritesStore.getState().toggle('BV1');
+    expect(result).toBe(false);
+    expect('BV1' in useFavoritesStore.getState().entries).toBe(false);
+  });
+
+  it('isFavored 反映存在性', () => {
+    expect(useFavoritesStore.getState().isFavored('BV1')).toBe(false);
+    useFavoritesStore.getState().add('BV1');
+    expect(useFavoritesStore.getState().isFavored('BV1')).toBe(true);
+  });
+
+  it('add：已存在 bvid 不覆盖原时间戳（保留"首次喜欢"）', () => {
+    useFavoritesStore.setState({ entries: { BV1: 100 } });
+    useFavoritesStore.getState().add('BV1');
+    expect(useFavoritesStore.getState().entries.BV1).toBe(100);
+  });
+
+  it('remove：不存在的 bvid 不抛错', () => {
+    expect(() => useFavoritesStore.getState().remove('not-exist')).not.toThrow();
+  });
+
+  it('clear：清空所有 entries', () => {
+    useFavoritesStore.setState({ entries: { BV1: 100, BV2: 200 } });
+    useFavoritesStore.getState().clear();
+    expect(useFavoritesStore.getState().entries).toEqual({});
+  });
+});
+
+describe('selectSortedBvids', () => {
+  it('desc：时间戳大的在前', () => {
+    expect(selectSortedBvids({ BV1: 100, BV2: 300, BV3: 200 }, 'desc')).toEqual([
+      'BV2',
+      'BV3',
+      'BV1',
+    ]);
+  });
+
+  it('asc：时间戳小的在前', () => {
+    expect(selectSortedBvids({ BV1: 100, BV2: 300, BV3: 200 }, 'asc')).toEqual([
+      'BV1',
+      'BV3',
+      'BV2',
+    ]);
+  });
+
+  it('同时间戳：按 bvid 字典序保证稳定', () => {
+    expect(selectSortedBvids({ BVc: 100, BVa: 100, BVb: 100 }, 'desc')).toEqual([
+      'BVa',
+      'BVb',
+      'BVc',
+    ]);
+  });
+
+  it('空 entries 返回空数组', () => {
+    expect(selectSortedBvids({}, 'desc')).toEqual([]);
+  });
+});

--- a/packages/shared/src/store/favorites.ts
+++ b/packages/shared/src/store/favorites.ts
@@ -1,0 +1,79 @@
+import { create } from 'zustand';
+import { timeStampNow } from '../utils';
+
+/**
+ * 系统级「我的收藏」store
+ *
+ * 设计要点：
+ * - entries 同时承载存在性 + 排序权重（bvid → 收藏时间戳，秒）
+ * - 与 useFavListStore 完全独立：不出现在 list[]，不参与 fav_list 合并
+ * - 路由保留字 ID 由调用方约定（packages/web 的 fav-list.tsx 用 'favorites'）
+ *
+ * 重复 add 时**不覆盖原时间戳**：保留"首次喜欢"的真实时间，避免误触改变排序位
+ */
+interface FavoritesState {
+  entries: Record<string, number>;
+
+  isFavored(bvid: string): boolean;
+  /** 切换收藏状态，返回切换后是否处于已收藏态 */
+  toggle(bvid: string): boolean;
+  /** 已存在则保留原时间戳；不存在则写入当前秒级时间戳 */
+  add(bvid: string): void;
+  remove(bvid: string): void;
+  clear(): void;
+}
+
+export const useFavoritesStore = create<FavoritesState>((set, get) => ({
+  entries: {},
+
+  isFavored: (bvid) => bvid in get().entries,
+
+  toggle: (bvid) => {
+    const existing = get().entries;
+    if (bvid in existing) {
+      const next = { ...existing };
+      delete next[bvid];
+      set({ entries: next });
+      return false;
+    }
+    set({ entries: { ...existing, [bvid]: timeStampNow() } });
+    return true;
+  },
+
+  add: (bvid) => {
+    const existing = get().entries;
+    if (bvid in existing) return;
+    set({ entries: { ...existing, [bvid]: timeStampNow() } });
+  },
+
+  remove: (bvid) => {
+    const existing = get().entries;
+    if (!(bvid in existing)) return;
+    const next = { ...existing };
+    delete next[bvid];
+    set({ entries: next });
+  },
+
+  clear: () => set({ entries: {} }),
+}));
+
+/** 排序方向：desc=最新收藏在前 / asc=最早收藏在前 */
+export type FavoritesOrder = 'desc' | 'asc';
+
+/**
+ * 派生：按时间戳排序后的 bvid 列表
+ *
+ * 同时间戳时按 bvid 字典序保证稳定（Object.entries 顺序在不同 JS 引擎下不保证）
+ */
+export function selectSortedBvids(
+  entries: Record<string, number>,
+  order: FavoritesOrder,
+): string[] {
+  const pairs = Object.entries(entries);
+  pairs.sort((a, b) => {
+    const tsDiff = order === 'desc' ? b[1] - a[1] : a[1] - b[1];
+    if (tsDiff !== 0) return tsDiff;
+    return a[0].localeCompare(b[0]);
+  });
+  return pairs.map(([bvid]) => bvid);
+}

--- a/packages/shared/src/store/index.ts
+++ b/packages/shared/src/store/index.ts
@@ -11,6 +11,8 @@ export { useRiskControlStore } from './risk-control';
 export { useMusicUrlCacheStore } from './music-url-cache';
 export type { MusicUrlCacheEntry } from './music-url-cache';
 export { useUpdateCheckerStore } from './update-checker';
+export { useFavoritesStore, selectSortedBvids } from './favorites';
+export type { FavoritesOrder } from './favorites';
 export type {
   NoticeItem,
   SendNoticePayload,
@@ -36,4 +38,5 @@ export type {
   PersistedCloudServiceShape,
   PersistedMusicUrlCacheShape,
   PersistedUpdateCheckerShape,
+  PersistedFavoritesShape,
 } from './persisted-types';

--- a/packages/shared/src/store/index.ts
+++ b/packages/shared/src/store/index.ts
@@ -13,6 +13,7 @@ export type { MusicUrlCacheEntry } from './music-url-cache';
 export { useUpdateCheckerStore } from './update-checker';
 export { useFavoritesStore, selectSortedBvids } from './favorites';
 export type { FavoritesOrder } from './favorites';
+export { useVideoPagePrefStore } from './video-page-pref';
 export type {
   NoticeItem,
   SendNoticePayload,
@@ -39,4 +40,5 @@ export type {
   PersistedMusicUrlCacheShape,
   PersistedUpdateCheckerShape,
   PersistedFavoritesShape,
+  PersistedVideoPagePrefShape,
 } from './persisted-types';

--- a/packages/shared/src/store/middleware/persist.test.ts
+++ b/packages/shared/src/store/middleware/persist.test.ts
@@ -141,7 +141,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     return entry;
   }
 
-  it('注册表覆盖 9 个 PERSIST_KEYS', () => {
+  it('注册表覆盖 10 个 PERSIST_KEYS', () => {
     const keys = STORE_PERSIST_REGISTRY.map((e) => e.key).sort();
     expect(keys).toEqual(
       [
@@ -154,6 +154,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
         'cloud_service',
         'music_url_cache',
         'update_checker',
+        'favorites',
       ].sort(),
     );
   });
@@ -198,6 +199,25 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     expect(useLyricsStore.getState().lyricMaps.BV1).toBeDefined();
   });
 
+  it('favorites hydrate / snapshot 往返一致', async () => {
+    const { useFavoritesStore } = await import('../favorites');
+    useFavoritesStore.setState({ entries: {} });
+
+    const data = { entries: { BV1: 100, BV2: 200 } };
+    getEntry('favorites').hydrate(data);
+    expect(useFavoritesStore.getState().entries).toEqual({ BV1: 100, BV2: 200 });
+
+    const snap = getEntry('favorites').snapshot() as typeof data;
+    expect(snap.entries).toEqual({ BV1: 100, BV2: 200 });
+  });
+
+  it('favorites hydrate 缺失 entries 字段兜底空对象', async () => {
+    const { useFavoritesStore } = await import('../favorites');
+    useFavoritesStore.setState({ entries: { BVx: 999 } });
+    getEntry('favorites').hydrate({});
+    expect(useFavoritesStore.getState().entries).toEqual({});
+  });
+
   it('cloud_service hydrate session（缺失 session 时不抛错）', () => {
     getEntry('cloud_service').hydrate({});
     expect(useCloudServiceStore.getState().session.token).toBe('');
@@ -231,7 +251,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it('collectPersistableSnapshot 聚合所有 7 个 store 当前状态', () => {
+  it('collectPersistableSnapshot 聚合所有 10 个 store 当前状态', () => {
     useFavListStore.setState({
       list: [{ id: 'a', name: 'A', type: 'CUSTOM' as never, bv_ids: [] } as never],
     });

--- a/packages/shared/src/store/middleware/persist.test.ts
+++ b/packages/shared/src/store/middleware/persist.test.ts
@@ -123,7 +123,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
       space: {},
       favFolders: {},
     });
-    usePlayingListStore.setState({ favId: '', bvIds: [], current: '', playNext: false });
+    usePlayingListStore.setState({ favId: '', trackIds: [], current: '', playNext: false });
     useFavListStore.setState({ list: [] });
     usePlayerProfileStore.setState({
       theme: 'auto',
@@ -141,7 +141,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     return entry;
   }
 
-  it('注册表覆盖 10 个 PERSIST_KEYS', () => {
+  it('注册表覆盖 11 个 PERSIST_KEYS', () => {
     const keys = STORE_PERSIST_REGISTRY.map((e) => e.key).sort();
     expect(keys).toEqual(
       [
@@ -155,6 +155,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
         'music_url_cache',
         'update_checker',
         'favorites',
+        'video_page_pref',
       ].sort(),
     );
   });
@@ -176,10 +177,77 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     expect(useBilibiliUserVideosStore.getState().infos['1']).toBeDefined();
   });
 
-  it('playing_list hydrate playNext 始终重置为 false', () => {
+  it('bili_user_videos hydrate strip 旧脏数据中的 :p<n> 后缀（E3）', () => {
+    getEntry('bili_user_videos').hydrate({
+      isLoading: false,
+      infos: {
+        '7': {
+          update_time: 100,
+          count: 2,
+          update_type: '',
+          video_list: [
+            { bvid: 'BV1Test:p2', created: 1 } as never,
+            { bvid: 'BV2Test', created: 2 } as never,
+          ],
+        },
+      },
+      favFolders: {
+        '99': {
+          update_time: 100,
+          count: 1,
+          update_type: '',
+          info: {},
+          video_list: [{ bvid: 'BV3Dirty:p5', created: 3 } as never],
+        } as never,
+      },
+    });
+    const infos = useBilibiliUserVideosStore.getState().infos;
+    expect(infos['7']?.video_list[0]?.bvid).toBe('BV1Test');
+    expect(infos['7']?.video_list[1]?.bvid).toBe('BV2Test');
+    const favFolders = useBilibiliUserVideosStore.getState().favFolders;
+    expect(favFolders['99']?.video_list[0]?.bvid).toBe('BV3Dirty');
+  });
+
+  it('bili_user_videos hydrate 干净数据保持引用不变（无浪费分配）', () => {
+    const cleanList = [{ bvid: 'BV1Clean', created: 1 }];
+    const cleanEntry = {
+      update_time: 100,
+      count: 1,
+      update_type: '' as const,
+      video_list: cleanList,
+    };
+    getEntry('bili_user_videos').hydrate({
+      isLoading: false,
+      infos: { '7': cleanEntry },
+    });
+    // cleanVideoListEntry 检测无脏值时直接返回原 entry 引用
+    expect(useBilibiliUserVideosStore.getState().infos['7']?.video_list).toBe(cleanList);
+  });
+
+  it('playing_list hydrate playNext 始终重置为 false（兼容旧 bvIds 字段名）', () => {
     getEntry('playing_list').hydrate({ favId: 'a', bvIds: ['BV1'], current: 'BV1' });
     expect(usePlayingListStore.getState().playNext).toBe(false);
-    expect(usePlayingListStore.getState().bvIds).toEqual(['BV1']);
+    expect(usePlayingListStore.getState().trackIds).toEqual(['BV1']);
+  });
+
+  it('playing_list hydrate 新字段 trackIds（B2 起）', () => {
+    getEntry('playing_list').hydrate({
+      favId: 'a',
+      trackIds: ['BV1', 'BV2:p3'],
+      current: 'BV2:p3',
+    });
+    expect(usePlayingListStore.getState().trackIds).toEqual(['BV1', 'BV2:p3']);
+    expect(usePlayingListStore.getState().current).toBe('BV2:p3');
+  });
+
+  it('playing_list hydrate trackIds 与 bvIds 同时存在时优先 trackIds', () => {
+    getEntry('playing_list').hydrate({
+      favId: 'a',
+      bvIds: ['LEGACY'],
+      trackIds: ['NEW'],
+      current: 'NEW',
+    });
+    expect(usePlayingListStore.getState().trackIds).toEqual(['NEW']);
   });
 
   it('fav_list hydrate 缺失字段兜底空数组', () => {
@@ -251,7 +319,7 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it('collectPersistableSnapshot 聚合所有 10 个 store 当前状态', () => {
+  it('collectPersistableSnapshot 聚合所有 11 个 store 当前状态', () => {
     useFavListStore.setState({
       list: [{ id: 'a', name: 'A', type: 'CUSTOM' as never, bv_ids: [] } as never],
     });

--- a/packages/shared/src/store/middleware/persist.test.ts
+++ b/packages/shared/src/store/middleware/persist.test.ts
@@ -17,6 +17,7 @@ import { useLyricsStore } from '../lyrics';
 import { usePlayerProfileStore } from '../player-profile';
 import { usePlayingListStore } from '../playing-list';
 import { useCloudServiceStore } from '../cloud-service';
+import { DEFAULT_FLOATING_LYRICS } from '../../types';
 
 function makeAdapter(): StorageAdapter & { _store: Map<string, string> } {
   const store = new Map<string, string>();
@@ -259,6 +260,40 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     getEntry('ui_profile').hydrate({ theme: 'dark', volume: 0.3 });
     expect(usePlayerProfileStore.getState().theme).toBe('dark');
     expect(usePlayerProfileStore.getState().volume).toBe(0.3);
+  });
+
+  it('ui_profile hydrate 无 floatingLyrics 字段时兜底为 DEFAULT_FLOATING_LYRICS', () => {
+    // 重置悬浮歌词字段，模拟"老用户没有此字段"的初始 store 状态
+    usePlayerProfileStore.setState({ floatingLyrics: { ...DEFAULT_FLOATING_LYRICS } });
+    // 老快照（B4 之前）不带 floatingLyrics
+    getEntry('ui_profile').hydrate({ theme: 'dark' });
+    expect(usePlayerProfileStore.getState().floatingLyrics).toEqual(DEFAULT_FLOATING_LYRICS);
+  });
+
+  it('ui_profile hydrate 部分 floatingLyrics 字段时与 DEFAULT 合并', () => {
+    getEntry('ui_profile').hydrate({
+      theme: 'dark',
+      floatingLyrics: { fontSize: 20, fontWeight: 'bold' },
+    });
+    const cfg = usePlayerProfileStore.getState().floatingLyrics;
+    expect(cfg.fontSize).toBe(20);
+    expect(cfg.fontWeight).toBe('bold');
+    // 未提供字段走 default
+    expect(cfg.textAlign).toBe(DEFAULT_FLOATING_LYRICS.textAlign);
+    expect(cfg.enabled).toBe(DEFAULT_FLOATING_LYRICS.enabled);
+    expect(cfg.bgOpacity).toBe(DEFAULT_FLOATING_LYRICS.bgOpacity);
+  });
+
+  it('ui_profile snapshot 包含 floatingLyrics 字段', () => {
+    usePlayerProfileStore.setState({
+      floatingLyrics: { ...DEFAULT_FLOATING_LYRICS, fontSize: 22, textAlign: 'left' },
+    });
+    const snap = getEntry('ui_profile').snapshot() as {
+      floatingLyrics?: { fontSize: number; textAlign: string };
+    };
+    expect(snap.floatingLyrics).toBeDefined();
+    expect(snap.floatingLyrics?.fontSize).toBe(22);
+    expect(snap.floatingLyrics?.textAlign).toBe('left');
   });
 
   it('lyrics hydrate', () => {

--- a/packages/shared/src/store/middleware/persist.ts
+++ b/packages/shared/src/store/middleware/persist.ts
@@ -21,6 +21,7 @@ import { useFavoritesStore } from '../favorites';
 import { useVideoPagePrefStore } from '../video-page-pref';
 import { hasPageSuffix, trackIdToBvid } from '../../utils/track-id';
 import type { FavFolderCacheEntry, VideoListCacheEntry } from '../../types';
+import { DEFAULT_FLOATING_LYRICS } from '../../types';
 import type {
   PersistedBilibiliUserVideosShape,
   PersistedBilibiliVideosShape,
@@ -228,7 +229,12 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
     hydrate(raw) {
       const data = asRecord(raw) as PersistedPlayerProfileShape | null;
       if (!data) return;
-      usePlayerProfileStore.setState(data);
+      // 老用户的 ui_profile 不含 floatingLyrics 字段，必须 spread DEFAULT 兜底，
+      // 否则渲染层访问 cfg.fontSize / cfg.textAlign 等会拿到 undefined 引发崩溃。
+      usePlayerProfileStore.setState({
+        ...data,
+        floatingLyrics: { ...DEFAULT_FLOATING_LYRICS, ...(data.floatingLyrics ?? {}) },
+      });
     },
     snapshot() {
       const s = usePlayerProfileStore.getState();
@@ -239,6 +245,7 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
         loopMode: s.loopMode,
         primaryColor: s.primaryColor,
         autoPlayNextPage: s.autoPlayNextPage,
+        floatingLyrics: s.floatingLyrics,
       };
     },
     subscribe(cb) {

--- a/packages/shared/src/store/middleware/persist.ts
+++ b/packages/shared/src/store/middleware/persist.ts
@@ -17,11 +17,13 @@ import { useLyricsStore } from '../lyrics';
 import { useCloudServiceStore } from '../cloud-service';
 import { useMusicUrlCacheStore } from '../music-url-cache';
 import { useUpdateCheckerStore } from '../update-checker';
+import { useFavoritesStore } from '../favorites';
 import type {
   PersistedBilibiliUserVideosShape,
   PersistedBilibiliVideosShape,
   PersistedCloudServiceShape,
   PersistedFavListShape,
+  PersistedFavoritesShape,
   PersistedLyricsShape,
   PersistedMusicUrlCacheShape,
   PersistedPlayerProfileShape,
@@ -105,7 +107,7 @@ interface StorePersistEntry {
 }
 
 /**
- * 7 个可持久化 store 的 hydrate / snapshot / subscribe 注册表
+ * 10 个可持久化 store 的 hydrate / snapshot / subscribe 注册表
  *
  * 形状契约由 PersistedXxxShape 维护；
  * - bili_user_videos 的 isLoading 必须强制重置为 false，否则恢复后停在加载态
@@ -263,6 +265,20 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
     },
     subscribe(cb) {
       return useUpdateCheckerStore.subscribe(cb);
+    },
+  },
+  {
+    key: 'favorites',
+    hydrate(raw) {
+      const data = asRecord(raw) as PersistedFavoritesShape | null;
+      if (!data) return;
+      useFavoritesStore.setState({ entries: data.entries ?? {} });
+    },
+    snapshot() {
+      return { entries: useFavoritesStore.getState().entries };
+    },
+    subscribe(cb) {
+      return useFavoritesStore.subscribe(cb);
     },
   },
 ];

--- a/packages/shared/src/store/middleware/persist.ts
+++ b/packages/shared/src/store/middleware/persist.ts
@@ -15,9 +15,12 @@ import { useFavListStore } from '../fav-list';
 import { usePlayerProfileStore } from '../player-profile';
 import { useLyricsStore } from '../lyrics';
 import { useCloudServiceStore } from '../cloud-service';
-import { useMusicUrlCacheStore } from '../music-url-cache';
+import { useMusicUrlCacheStore, type MusicUrlCacheEntry } from '../music-url-cache';
 import { useUpdateCheckerStore } from '../update-checker';
 import { useFavoritesStore } from '../favorites';
+import { useVideoPagePrefStore } from '../video-page-pref';
+import { hasPageSuffix, trackIdToBvid } from '../../utils/track-id';
+import type { FavFolderCacheEntry, VideoListCacheEntry } from '../../types';
 import type {
   PersistedBilibiliUserVideosShape,
   PersistedBilibiliVideosShape,
@@ -29,10 +32,42 @@ import type {
   PersistedPlayerProfileShape,
   PersistedPlayingListShape,
   PersistedUpdateCheckerShape,
+  PersistedVideoPagePrefShape,
 } from '../persisted-types';
 
 /** 持久化数据的根 key */
 export const PERSIST_DATA_KEY = 'player_data';
+
+/**
+ * §2 不变量防御（E3）：清洗 VideoListCacheEntry.video_list 中的 bvid 字段，
+ * 若含 ':p<n>' 后缀（旧脏数据 / 错误手改），strip 回纯 bvid 形式。
+ *
+ * Fast path：先 O(N) `some` 扫描，无脏值时直接返回原 entry 引用，避免无效分配。
+ */
+function cleanVideoListEntry<T extends VideoListCacheEntry>(entry: T): T {
+  if (!entry?.video_list?.length) return entry;
+  if (!entry.video_list.some((it) => hasPageSuffix(it?.bvid))) return entry;
+  const cleanedList = entry.video_list.map((it) =>
+    hasPageSuffix(it?.bvid) ? { bvid: trackIdToBvid(it.bvid), created: it.created } : it,
+  );
+  return { ...entry, video_list: cleanedList };
+}
+
+function cleanInfosShape(infos: Record<string, VideoListCacheEntry>): typeof infos {
+  const out: Record<string, VideoListCacheEntry> = {};
+  for (const [mid, entry] of Object.entries(infos)) {
+    out[mid] = cleanVideoListEntry(entry);
+  }
+  return out;
+}
+
+function cleanFavFoldersShape(folders: Record<string, FavFolderCacheEntry>): typeof folders {
+  const out: Record<string, FavFolderCacheEntry> = {};
+  for (const [id, entry] of Object.entries(folders)) {
+    out[id] = cleanVideoListEntry(entry);
+  }
+  return out;
+}
 
 /**
  * 简易尾沿节流：在窗口期内最后一次调用会在窗口结束时执行
@@ -107,7 +142,7 @@ interface StorePersistEntry {
 }
 
 /**
- * 10 个可持久化 store 的 hydrate / snapshot / subscribe 注册表
+ * 11 个可持久化 store 的 hydrate / snapshot / subscribe 注册表
  *
  * 形状契约由 PersistedXxxShape 维护；
  * - bili_user_videos 的 isLoading 必须强制重置为 false，否则恢复后停在加载态
@@ -137,11 +172,13 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
     hydrate(raw) {
       const data = asRecord(raw) as PersistedBilibiliUserVideosShape | null;
       if (!data) return;
+      // §2 不变量（E3）：UPLOADER / BILI_FAV 的 video_list[].bvid 永远是纯 bvid。
+      // 旧持久化数据可能含脏字符串（如旧版/手改 import 注入了 :p<n>），hydrate 时 strip 防御。
       useBilibiliUserVideosStore.setState({
         isLoading: false,
-        infos: data.infos ?? {},
+        infos: cleanInfosShape(data.infos ?? {}),
         space: data.space ?? {},
-        favFolders: data.favFolders ?? {},
+        favFolders: cleanFavFoldersShape(data.favFolders ?? {}),
       });
     },
     snapshot() {
@@ -156,16 +193,17 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
     hydrate(raw) {
       const data = asRecord(raw) as PersistedPlayingListShape | null;
       if (!data) return;
+      // B2 兼容：旧字段名 bvIds 与新字段名 trackIds 都接受，优先新字段
       usePlayingListStore.setState({
         favId: data.favId ?? '',
-        bvIds: data.bvIds ?? [],
+        trackIds: data.trackIds ?? data.bvIds ?? [],
         current: data.current ?? '',
         playNext: false,
       });
     },
     snapshot() {
       const s = usePlayingListStore.getState();
-      return { favId: s.favId, bvIds: s.bvIds, current: s.current };
+      return { favId: s.favId, trackIds: s.trackIds, current: s.current };
     },
     subscribe(cb) {
       return usePlayingListStore.subscribe(cb);
@@ -200,6 +238,7 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
         autoPlay: s.autoPlay,
         loopMode: s.loopMode,
         primaryColor: s.primaryColor,
+        autoPlayNextPage: s.autoPlayNextPage,
       };
     },
     subscribe(cb) {
@@ -239,7 +278,17 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
     hydrate(raw) {
       const data = asRecord(raw) as PersistedMusicUrlCacheShape | null;
       if (!data) return;
-      useMusicUrlCacheStore.setState({ entries: data.entries ?? {} });
+      // 自 A5 起 cache key 形态为 `${bvid}:${cid}`，丢弃旧形态（不含 ':'），
+      // 防止旧持久化数据被错误命中（旧 value 有 cid 字段，新 value 无 cid）。
+      const clean: Record<string, MusicUrlCacheEntry> = {};
+      for (const [key, value] of Object.entries(data.entries ?? {})) {
+        if (!key.includes(':')) continue;
+        if (!value || typeof value !== 'object') continue;
+        const v = value as { playUrl?: unknown; last_update?: unknown };
+        if (typeof v.playUrl !== 'string' || typeof v.last_update !== 'number') continue;
+        clean[key] = { playUrl: v.playUrl, last_update: v.last_update };
+      }
+      useMusicUrlCacheStore.setState({ entries: clean });
     },
     snapshot() {
       return useMusicUrlCacheStore.getState().persistSnapshot();
@@ -279,6 +328,27 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
     },
     subscribe(cb) {
       return useFavoritesStore.subscribe(cb);
+    },
+  },
+  {
+    key: 'video_page_pref',
+    hydrate(raw) {
+      const data = asRecord(raw) as PersistedVideoPagePrefShape | null;
+      if (!data) return;
+      // 防御性过滤：忽略 page <= 1 / 非整数的脏值
+      const clean: Record<string, number> = {};
+      for (const [bvid, page] of Object.entries(data.defaultPage ?? {})) {
+        if (typeof page === 'number' && Number.isInteger(page) && page >= 2) {
+          clean[bvid] = page;
+        }
+      }
+      useVideoPagePrefStore.setState({ defaultPage: clean });
+    },
+    snapshot() {
+      return { defaultPage: useVideoPagePrefStore.getState().defaultPage };
+    },
+    subscribe(cb) {
+      return useVideoPagePrefStore.subscribe(cb);
     },
   },
 ];

--- a/packages/shared/src/store/music-url-cache.test.ts
+++ b/packages/shared/src/store/music-url-cache.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMusicUrlCacheStore, makeCacheKey } from './music-url-cache';
+import { MUSIC_URL_CACHE_TTL } from '../constants';
+
+describe('useMusicUrlCacheStore（A5 升级后：key = bvid:cid）', () => {
+  beforeEach(() => {
+    useMusicUrlCacheStore.setState({ entries: {} });
+  });
+
+  it('makeCacheKey 拼接为 `${bvid}:${cid}`', () => {
+    expect(makeCacheKey('BV1', 100)).toBe('BV1:100');
+  });
+
+  it('upsert 写入到 bvid:cid key，value 不再保存 cid', () => {
+    useMusicUrlCacheStore.getState().upsert('BV1', 100, { playUrl: 'https://x/a' });
+    const entries = useMusicUrlCacheStore.getState().entries;
+    expect(entries['BV1:100']?.playUrl).toBe('https://x/a');
+    expect(entries['BV1:100']?.last_update).toBeGreaterThan(0);
+    expect(Object.prototype.hasOwnProperty.call(entries['BV1:100'], 'cid')).toBe(false);
+    // 旧 key 形态不存在
+    expect(entries['BV1']).toBeUndefined();
+  });
+
+  it('同 bvid 不同 cid 的多 P 互不覆盖', () => {
+    useMusicUrlCacheStore.getState().upsert('BV1', 100, { playUrl: 'https://x/p1' });
+    useMusicUrlCacheStore.getState().upsert('BV1', 200, { playUrl: 'https://x/p2' });
+    const entries = useMusicUrlCacheStore.getState().entries;
+    expect(entries['BV1:100']?.playUrl).toBe('https://x/p1');
+    expect(entries['BV1:200']?.playUrl).toBe('https://x/p2');
+  });
+
+  it('getValid 命中未过期条目', () => {
+    useMusicUrlCacheStore.getState().upsert('BV1', 100, { playUrl: 'https://x/a' });
+    expect(useMusicUrlCacheStore.getState().getValid('BV1', 100)?.playUrl).toBe('https://x/a');
+  });
+
+  it('getValid 过期返回 undefined', () => {
+    useMusicUrlCacheStore.setState({
+      entries: {
+        'BV1:100': { playUrl: 'https://x/a', last_update: 0 },
+      },
+    });
+    expect(useMusicUrlCacheStore.getState().getValid('BV1', 100)).toBeUndefined();
+  });
+
+  it('getValid 错位 cid 返回 undefined', () => {
+    useMusicUrlCacheStore.getState().upsert('BV1', 100, { playUrl: 'https://x/a' });
+    expect(useMusicUrlCacheStore.getState().getValid('BV1', 999)).toBeUndefined();
+  });
+
+  it('invalidate(bvid) 清空该 bvid 下所有 P', () => {
+    useMusicUrlCacheStore.setState({
+      entries: {
+        'BV1:100': { playUrl: 'a', last_update: Date.now() / 1000 },
+        'BV1:200': { playUrl: 'b', last_update: Date.now() / 1000 },
+        'BV2:300': { playUrl: 'c', last_update: Date.now() / 1000 },
+      },
+    });
+    useMusicUrlCacheStore.getState().invalidate('BV1');
+    const entries = useMusicUrlCacheStore.getState().entries;
+    expect(entries['BV1:100']).toBeUndefined();
+    expect(entries['BV1:200']).toBeUndefined();
+    expect(entries['BV2:300']).toBeDefined();
+  });
+
+  it('invalidate() 清空全部', () => {
+    useMusicUrlCacheStore.setState({
+      entries: {
+        'BV1:100': { playUrl: 'a', last_update: Date.now() / 1000 },
+        'BV2:200': { playUrl: 'b', last_update: Date.now() / 1000 },
+      },
+    });
+    useMusicUrlCacheStore.getState().invalidate();
+    expect(useMusicUrlCacheStore.getState().entries).toEqual({});
+  });
+
+  it('invalidate 对不命中 bvid 不变更引用（性能保障）', () => {
+    const before = { 'BV1:100': { playUrl: 'a', last_update: Date.now() / 1000 } };
+    useMusicUrlCacheStore.setState({ entries: before });
+    useMusicUrlCacheStore.getState().invalidate('BVX');
+    expect(useMusicUrlCacheStore.getState().entries).toBe(before);
+  });
+
+  it('persistSnapshot 剔除过期项与不含 ":" 的旧形态 key', () => {
+    const now = Math.floor(Date.now() / 1000);
+    useMusicUrlCacheStore.setState({
+      entries: {
+        'BV1:100': { playUrl: 'fresh', last_update: now },
+        'BV2:200': { playUrl: 'expired', last_update: now - MUSIC_URL_CACHE_TTL - 1 },
+        // 旧形态 key（A5 前的 bvid 索引）应被丢弃
+        BV3: { playUrl: 'legacy', last_update: now },
+      },
+    });
+    const snap = useMusicUrlCacheStore.getState().persistSnapshot();
+    expect(snap.entries['BV1:100']).toBeDefined();
+    expect(snap.entries['BV2:200']).toBeUndefined();
+    expect(snap.entries['BV3']).toBeUndefined();
+  });
+});

--- a/packages/shared/src/store/music-url-cache.ts
+++ b/packages/shared/src/store/music-url-cache.ts
@@ -5,6 +5,9 @@ import { timeStampNow } from '../utils/format';
 /**
  * 持久化的播放 URL 缓存条目（裁剪版）
  *
+ * key 形态：`${bvid}:${cid}`（自 A5 起；旧版 `bvid` 单值在 hydrate 时被丢弃）。
+ * cid 上提到 key 后，value 不再保存重复信息。
+ *
  * 仅保留下次 fetchMusicUrl 命中所需的最小字段，不持久化 viewInfo / playInfo
  * 完整结构（体积可能 5-20KB/首），避免重度听众累计写入 player_data 造成膨胀。
  */
@@ -13,20 +16,25 @@ export interface MusicUrlCacheEntry {
   playUrl: string;
   /** 写入时间戳（unix 秒）；与 MUSIC_URL_CACHE_TTL 比对决定是否过期 */
   last_update: number;
-  /** 视频单 P 的 cid；若已知则下次 fetchMusicUrl 可直接调 playurl，跳过 view */
-  cid?: number;
+}
+
+/** 组装缓存 key：`${bvid}:${cid}` */
+export function makeCacheKey(bvid: string, cid: number): string {
+  return `${bvid}:${cid}`;
 }
 
 interface MusicUrlCacheState {
   entries: Record<string, MusicUrlCacheEntry>;
 
   /** 命中且未过期则返回；否则返回 undefined（不主动删除过期项，由 persistSnapshot 统一清扫） */
-  getValid: (bvid: string) => MusicUrlCacheEntry | undefined;
+  getValid: (bvid: string, cid: number) => MusicUrlCacheEntry | undefined;
   /** 写入或更新一条缓存（含 last_update 自动赋值） */
-  upsert: (bvid: string, entry: Omit<MusicUrlCacheEntry, 'last_update'>) => void;
-  /** 仅更新已有条目的 cid（view 调用回填用，不影响 last_update / playUrl 状态） */
-  upsertCidOnly: (bvid: string, cid: number) => void;
-  /** 单条 / 全部失效（与 invalidateMusicUrlCache 入参对齐） */
+  upsert: (bvid: string, cid: number, entry: Omit<MusicUrlCacheEntry, 'last_update'>) => void;
+  /**
+   * 失效：
+   * - 无参：清空全部
+   * - 仅传 bvid：清空该 bvid 下所有 P（前缀匹配 `${bvid}:`）
+   */
   invalidate: (bvid?: string) => void;
   /** 持久化前清扫已过期条目，避免长跑后 entries 单调增长 */
   persistSnapshot: () => Pick<MusicUrlCacheState, 'entries'>;
@@ -35,34 +43,25 @@ interface MusicUrlCacheState {
 export const useMusicUrlCacheStore = create<MusicUrlCacheState>((set, get) => ({
   entries: {},
 
-  getValid: (bvid) => {
-    const e = get().entries[bvid];
+  getValid: (bvid, cid) => {
+    const key = makeCacheKey(bvid, cid);
+    const e = get().entries[key];
     if (!e || !e.playUrl) return undefined;
     if (e.last_update + MUSIC_URL_CACHE_TTL <= timeStampNow()) return undefined;
     return e;
   },
 
-  upsert: (bvid, payload) => {
+  upsert: (bvid, cid, payload) => {
+    const key = makeCacheKey(bvid, cid);
     set((state) => ({
       entries: {
         ...state.entries,
-        [bvid]: {
+        [key]: {
           playUrl: payload.playUrl,
-          cid: payload.cid,
           last_update: timeStampNow(),
         },
       },
     }));
-  },
-
-  upsertCidOnly: (bvid, cid) => {
-    set((state) => {
-      const old = state.entries[bvid];
-      // 没有现成条目就不写：避免拉一个 playUrl='' 的孤儿项被 getValid 当成 hit
-      if (!old) return state;
-      if (old.cid === cid) return state;
-      return { entries: { ...state.entries, [bvid]: { ...old, cid } } };
-    });
   },
 
   invalidate: (bvid) => {
@@ -71,9 +70,17 @@ export const useMusicUrlCacheStore = create<MusicUrlCacheState>((set, get) => ({
       return;
     }
     set((state) => {
-      if (!state.entries[bvid]) return state;
-      const next = { ...state.entries };
-      delete next[bvid];
+      const prefix = `${bvid}:`;
+      let changed = false;
+      const next: Record<string, MusicUrlCacheEntry> = {};
+      for (const [k, v] of Object.entries(state.entries)) {
+        if (k.startsWith(prefix)) {
+          changed = true;
+          continue;
+        }
+        next[k] = v;
+      }
+      if (!changed) return state;
       return { entries: next };
     });
   },
@@ -81,9 +88,10 @@ export const useMusicUrlCacheStore = create<MusicUrlCacheState>((set, get) => ({
   persistSnapshot: () => {
     const now = timeStampNow();
     const next: Record<string, MusicUrlCacheEntry> = {};
-    for (const [bvid, e] of Object.entries(get().entries)) {
-      // 持久化前剔除已过期的 entry：避免重启后 entries 单调累积
-      if (e.last_update + MUSIC_URL_CACHE_TTL > now) next[bvid] = e;
+    for (const [key, e] of Object.entries(get().entries)) {
+      // 持久化前剔除已过期 / 旧形态（不含 ':'）的 entry
+      if (!key.includes(':')) continue;
+      if (e.last_update + MUSIC_URL_CACHE_TTL > now) next[key] = e;
     }
     return { entries: next };
   },

--- a/packages/shared/src/store/persisted-types.ts
+++ b/packages/shared/src/store/persisted-types.ts
@@ -14,6 +14,7 @@ import type {
   CloudServiceSession,
   FavFolderCacheEntry,
   FavListItem,
+  FloatingLyricsConfig,
   LoopMode,
   LyricEntry,
   VideoListCacheEntry,
@@ -55,6 +56,11 @@ export interface PersistedPlayerProfileShape {
   primaryColor?: string;
   /** 多 P 投稿自动连续播放（B4 起，默认 false） */
   autoPlayNextPage?: boolean;
+  /**
+   * 悬浮歌词配置；老用户无此字段，hydrate 必须 spread DEFAULT_FLOATING_LYRICS 兜底。
+   * 字段级 partial：从老版本升级或外部 import 可能只带部分键。
+   */
+  floatingLyrics?: Partial<FloatingLyricsConfig>;
 }
 
 export interface PersistedLyricsShape {

--- a/packages/shared/src/store/persisted-types.ts
+++ b/packages/shared/src/store/persisted-types.ts
@@ -1,5 +1,5 @@
 /**
- * 10 个持久化 store 的"对外快照形状"统一定义
+ * 11 个持久化 store 的"对外快照形状"统一定义
  *
  * 与 store 内部 State 的差异：
  * - 仅声明会被写入 player_data 的字段（去掉 actions、瞬态字段）
@@ -35,6 +35,9 @@ export interface PersistedBilibiliUserVideosShape {
 
 export interface PersistedPlayingListShape {
   favId?: string;
+  /** 当前字段；旧版本（A 系列前）使用 bvIds，hydrate 时兼容读取 */
+  trackIds?: string[];
+  /** @deprecated 仅用于 hydrate 兼容，新代码不要写入 */
   bvIds?: string[];
   current?: string;
 }
@@ -50,6 +53,8 @@ export interface PersistedPlayerProfileShape {
   loopMode?: LoopMode;
   /** HSL 主色字符串（如 "221.2 83.2% 53.3%"），与 globals.css --primary 同语义 */
   primaryColor?: string;
+  /** 多 P 投稿自动连续播放（B4 起，默认 false） */
+  autoPlayNextPage?: boolean;
 }
 
 export interface PersistedLyricsShape {
@@ -74,6 +79,11 @@ export interface PersistedUpdateCheckerShape {
 }
 
 export interface PersistedFavoritesShape {
-  /** bvid → 收藏时间戳（秒） */
+  /** TrackId（bvid 或 bvid:p<n>） → 收藏时间戳（秒） */
   entries?: Record<string, number>;
+}
+
+export interface PersistedVideoPagePrefShape {
+  /** bvid → 默认 P（>= 2） */
+  defaultPage?: Record<string, number>;
 }

--- a/packages/shared/src/store/persisted-types.ts
+++ b/packages/shared/src/store/persisted-types.ts
@@ -1,5 +1,5 @@
 /**
- * 7 个持久化 store 的"对外快照形状"统一定义
+ * 10 个持久化 store 的"对外快照形状"统一定义
  *
  * 与 store 内部 State 的差异：
  * - 仅声明会被写入 player_data 的字段（去掉 actions、瞬态字段）
@@ -71,4 +71,9 @@ export interface PersistedUpdateCheckerShape {
   latestKnown?: UpdateInfo | null;
   /** 用户主动忽略的版本号集合 */
   ignoredVersions?: string[];
+}
+
+export interface PersistedFavoritesShape {
+  /** bvid → 收藏时间戳（秒） */
+  entries?: Record<string, number>;
 }

--- a/packages/shared/src/store/player-profile.test.ts
+++ b/packages/shared/src/store/player-profile.test.ts
@@ -48,6 +48,36 @@ describe('usePlayerProfileStore', () => {
     expect(usePlayerProfileStore.getState().autoPlay).toBe(true);
   });
 
+  describe('autoPlayNextPage（B4）', () => {
+    it('默认值为 false', () => {
+      // 不调用 reset 中的 setState，直接拿初始 state
+      usePlayerProfileStore.setState({
+        theme: 'auto',
+        volume: 0.8,
+        autoPlay: false,
+        loopMode: 'loop',
+        autoPlayNextPage: false,
+      });
+      expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(false);
+    });
+
+    it('setAutoPlayNextPage 切换开关', () => {
+      usePlayerProfileStore.getState().setAutoPlayNextPage(true);
+      expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(true);
+      usePlayerProfileStore.getState().setAutoPlayNextPage(false);
+      expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(false);
+    });
+
+    it('setAutoPlayNextPage 强制布尔化', () => {
+      // @ts-expect-error 测试非布尔输入
+      usePlayerProfileStore.getState().setAutoPlayNextPage(1);
+      expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(true);
+      // @ts-expect-error 测试非布尔输入
+      usePlayerProfileStore.getState().setAutoPlayNextPage(null);
+      expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(false);
+    });
+  });
+
   describe('getEffectiveTheme', () => {
     it('明确 light 时返回 light', () => {
       usePlayerProfileStore.setState({ theme: 'light' });

--- a/packages/shared/src/store/player-profile.test.ts
+++ b/packages/shared/src/store/player-profile.test.ts
@@ -1,4 +1,5 @@
 import { usePlayerProfileStore } from './player-profile';
+import { DEFAULT_FLOATING_LYRICS } from '../types';
 
 function reset() {
   usePlayerProfileStore.setState({
@@ -6,6 +7,7 @@ function reset() {
     volume: 0.8,
     autoPlay: false,
     loopMode: 'loop',
+    floatingLyrics: { ...DEFAULT_FLOATING_LYRICS },
   });
 }
 
@@ -75,6 +77,96 @@ describe('usePlayerProfileStore', () => {
       // @ts-expect-error 测试非布尔输入
       usePlayerProfileStore.getState().setAutoPlayNextPage(null);
       expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(false);
+    });
+  });
+
+  describe('floatingLyrics', () => {
+    it('默认值与 DEFAULT_FLOATING_LYRICS 一致', () => {
+      expect(usePlayerProfileStore.getState().floatingLyrics).toEqual(DEFAULT_FLOATING_LYRICS);
+    });
+
+    it('setFloatingLyrics 部分合并', () => {
+      usePlayerProfileStore.getState().setFloatingLyrics({ fontSize: 18 });
+      const cfg = usePlayerProfileStore.getState().floatingLyrics;
+      expect(cfg.fontSize).toBe(18);
+      // 其他字段保留默认
+      expect(cfg.fontWeight).toBe(DEFAULT_FLOATING_LYRICS.fontWeight);
+      expect(cfg.textAlign).toBe(DEFAULT_FLOATING_LYRICS.textAlign);
+    });
+
+    it('setFloatingLyrics 对 fontSize 做 clamp（>32 → 32）', () => {
+      usePlayerProfileStore.getState().setFloatingLyrics({ fontSize: 80 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.fontSize).toBe(32);
+    });
+
+    it('setFloatingLyrics 对 fontSize 做 clamp（<12 → 12）', () => {
+      usePlayerProfileStore.getState().setFloatingLyrics({ fontSize: 1 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.fontSize).toBe(12);
+    });
+
+    it('setFloatingLyrics 对 bgOpacity 做 clamp（0-1）', () => {
+      usePlayerProfileStore.getState().setFloatingLyrics({ bgOpacity: 2 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.bgOpacity).toBe(1);
+      usePlayerProfileStore.getState().setFloatingLyrics({ bgOpacity: -0.5 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.bgOpacity).toBe(0);
+    });
+
+    it('setFloatingLyrics 对 verticalOffset 做 clamp（16-64）', () => {
+      usePlayerProfileStore.getState().setFloatingLyrics({ verticalOffset: 200 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.verticalOffset).toBe(64);
+      usePlayerProfileStore.getState().setFloatingLyrics({ verticalOffset: -10 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.verticalOffset).toBe(16);
+      usePlayerProfileStore.getState().setFloatingLyrics({ verticalOffset: 8 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.verticalOffset).toBe(16);
+    });
+
+    it('setFloatingLyrics 枚举白名单防御：非法 textAlign 被忽略', () => {
+      const before = usePlayerProfileStore.getState().floatingLyrics.textAlign;
+      // @ts-expect-error 测试非法值
+      usePlayerProfileStore.getState().setFloatingLyrics({ textAlign: 'justify' });
+      expect(usePlayerProfileStore.getState().floatingLyrics.textAlign).toBe(before);
+    });
+
+    it('setFloatingLyrics 枚举白名单防御：非法 fontFamily 被忽略', () => {
+      const before = usePlayerProfileStore.getState().floatingLyrics.fontFamily;
+      // @ts-expect-error 测试非法值
+      usePlayerProfileStore.getState().setFloatingLyrics({ fontFamily: 'comic' });
+      expect(usePlayerProfileStore.getState().floatingLyrics.fontFamily).toBe(before);
+    });
+
+    it('setFloatingLyrics 枚举白名单防御：非法 textColor 被忽略', () => {
+      const before = usePlayerProfileStore.getState().floatingLyrics.textColor;
+      // @ts-expect-error 测试非法值
+      usePlayerProfileStore.getState().setFloatingLyrics({ textColor: '#ff0000' });
+      expect(usePlayerProfileStore.getState().floatingLyrics.textColor).toBe(before);
+    });
+
+    it('setFloatingLyrics enabled 强制布尔化', () => {
+      // @ts-expect-error 测试非布尔输入
+      usePlayerProfileStore.getState().setFloatingLyrics({ enabled: 1 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.enabled).toBe(true);
+      // @ts-expect-error 测试非布尔输入
+      usePlayerProfileStore.getState().setFloatingLyrics({ enabled: 0 });
+      expect(usePlayerProfileStore.getState().floatingLyrics.enabled).toBe(false);
+    });
+
+    it('toggleFloatingLyrics 翻转 enabled', () => {
+      const initial = usePlayerProfileStore.getState().floatingLyrics.enabled;
+      usePlayerProfileStore.getState().toggleFloatingLyrics();
+      expect(usePlayerProfileStore.getState().floatingLyrics.enabled).toBe(!initial);
+      usePlayerProfileStore.getState().toggleFloatingLyrics();
+      expect(usePlayerProfileStore.getState().floatingLyrics.enabled).toBe(initial);
+    });
+
+    it('resetFloatingLyrics 重置全部字段', () => {
+      usePlayerProfileStore.getState().setFloatingLyrics({
+        fontSize: 24,
+        fontWeight: 'bold',
+        textAlign: 'left',
+        enabled: false,
+      });
+      usePlayerProfileStore.getState().resetFloatingLyrics();
+      expect(usePlayerProfileStore.getState().floatingLyrics).toEqual(DEFAULT_FLOATING_LYRICS);
     });
   });
 

--- a/packages/shared/src/store/player-profile.ts
+++ b/packages/shared/src/store/player-profile.ts
@@ -9,6 +9,7 @@ interface PlayerProfileState extends PlayerProfile {
   setAutoPlay: (autoPlay: boolean) => void;
   setPrimaryColor: (color: string) => void;
   resetPrimaryColor: () => void;
+  setAutoPlayNextPage: (enabled: boolean) => void;
   /** 解析 'auto' 主题为实际 light/dark（依赖 prefers-color-scheme） */
   getEffectiveTheme: () => 'light' | 'dark';
 }
@@ -19,6 +20,7 @@ export const usePlayerProfileStore = create<PlayerProfileState>((set, get) => ({
   autoPlay: false,
   loopMode: 'loop',
   primaryColor: DEFAULT_PRIMARY_COLOR,
+  autoPlayNextPage: false,
 
   setTheme: (theme) => set({ theme }),
   setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
@@ -26,6 +28,7 @@ export const usePlayerProfileStore = create<PlayerProfileState>((set, get) => ({
   setAutoPlay: (autoPlay) => set({ autoPlay }),
   setPrimaryColor: (color) => set({ primaryColor: color || DEFAULT_PRIMARY_COLOR }),
   resetPrimaryColor: () => set({ primaryColor: DEFAULT_PRIMARY_COLOR }),
+  setAutoPlayNextPage: (enabled) => set({ autoPlayNextPage: Boolean(enabled) }),
 
   getEffectiveTheme: () => {
     const { theme } = get();

--- a/packages/shared/src/store/player-profile.ts
+++ b/packages/shared/src/store/player-profile.ts
@@ -1,6 +1,67 @@
 import { create } from 'zustand';
-import type { LoopMode, PlayerProfile } from '../types';
-import { DEFAULT_PRIMARY_COLOR } from '../types';
+import type {
+  FloatingLyricsConfig,
+  FloatingLyricsAlign,
+  FloatingLyricsFamily,
+  FloatingLyricsWeight,
+  FloatingLyricsColor,
+  LoopMode,
+  PlayerProfile,
+} from '../types';
+import { DEFAULT_FLOATING_LYRICS, DEFAULT_PRIMARY_COLOR } from '../types';
+
+const FLOATING_LYRICS_ALIGN_SET: ReadonlySet<FloatingLyricsAlign> = new Set([
+  'left',
+  'center',
+  'right',
+]);
+const FLOATING_LYRICS_WEIGHT_SET: ReadonlySet<FloatingLyricsWeight> = new Set(['normal', 'bold']);
+const FLOATING_LYRICS_FAMILY_SET: ReadonlySet<FloatingLyricsFamily> = new Set([
+  'sans',
+  'serif',
+  'mono',
+]);
+const FLOATING_LYRICS_COLOR_SET: ReadonlySet<FloatingLyricsColor> = new Set([
+  '',
+  'primary',
+  'white',
+  'black',
+  'muted',
+]);
+
+/**
+ * 字段级 clamp + 白名单校验：防止设置面板或导入的脏数据越界 / 注入非法枚举值。
+ * 未提供的字段保持上一次状态（caller 用 store.floatingLyrics 兜底）。
+ */
+function sanitizeFloatingLyricsPatch(
+  patch: Partial<FloatingLyricsConfig>,
+  prev: FloatingLyricsConfig,
+): FloatingLyricsConfig {
+  const next: FloatingLyricsConfig = { ...prev };
+  if (patch.enabled !== undefined) next.enabled = Boolean(patch.enabled);
+  if (patch.fontSize !== undefined && Number.isFinite(patch.fontSize)) {
+    next.fontSize = Math.min(32, Math.max(12, Math.round(patch.fontSize)));
+  }
+  if (patch.fontWeight !== undefined && FLOATING_LYRICS_WEIGHT_SET.has(patch.fontWeight)) {
+    next.fontWeight = patch.fontWeight;
+  }
+  if (patch.fontFamily !== undefined && FLOATING_LYRICS_FAMILY_SET.has(patch.fontFamily)) {
+    next.fontFamily = patch.fontFamily;
+  }
+  if (patch.textAlign !== undefined && FLOATING_LYRICS_ALIGN_SET.has(patch.textAlign)) {
+    next.textAlign = patch.textAlign;
+  }
+  if (patch.verticalOffset !== undefined && Number.isFinite(patch.verticalOffset)) {
+    next.verticalOffset = Math.min(64, Math.max(16, Math.round(patch.verticalOffset)));
+  }
+  if (patch.textColor !== undefined && FLOATING_LYRICS_COLOR_SET.has(patch.textColor)) {
+    next.textColor = patch.textColor;
+  }
+  if (patch.bgOpacity !== undefined && Number.isFinite(patch.bgOpacity)) {
+    next.bgOpacity = Math.min(1, Math.max(0, patch.bgOpacity));
+  }
+  return next;
+}
 
 interface PlayerProfileState extends PlayerProfile {
   setTheme: (theme: 'light' | 'dark' | 'auto') => void;
@@ -10,6 +71,12 @@ interface PlayerProfileState extends PlayerProfile {
   setPrimaryColor: (color: string) => void;
   resetPrimaryColor: () => void;
   setAutoPlayNextPage: (enabled: boolean) => void;
+  /** 部分更新悬浮歌词配置（patch 内部 clamp + 枚举白名单防御） */
+  setFloatingLyrics: (patch: Partial<FloatingLyricsConfig>) => void;
+  /** 翻转 enabled —— 供右下角按钮直接调用 */
+  toggleFloatingLyrics: () => void;
+  /** 重置为 DEFAULT_FLOATING_LYRICS */
+  resetFloatingLyrics: () => void;
   /** 解析 'auto' 主题为实际 light/dark（依赖 prefers-color-scheme） */
   getEffectiveTheme: () => 'light' | 'dark';
 }
@@ -21,6 +88,7 @@ export const usePlayerProfileStore = create<PlayerProfileState>((set, get) => ({
   loopMode: 'loop',
   primaryColor: DEFAULT_PRIMARY_COLOR,
   autoPlayNextPage: false,
+  floatingLyrics: { ...DEFAULT_FLOATING_LYRICS },
 
   setTheme: (theme) => set({ theme }),
   setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
@@ -29,6 +97,14 @@ export const usePlayerProfileStore = create<PlayerProfileState>((set, get) => ({
   setPrimaryColor: (color) => set({ primaryColor: color || DEFAULT_PRIMARY_COLOR }),
   resetPrimaryColor: () => set({ primaryColor: DEFAULT_PRIMARY_COLOR }),
   setAutoPlayNextPage: (enabled) => set({ autoPlayNextPage: Boolean(enabled) }),
+
+  setFloatingLyrics: (patch) =>
+    set((state) => ({ floatingLyrics: sanitizeFloatingLyricsPatch(patch, state.floatingLyrics) })),
+  toggleFloatingLyrics: () =>
+    set((state) => ({
+      floatingLyrics: { ...state.floatingLyrics, enabled: !state.floatingLyrics.enabled },
+    })),
+  resetFloatingLyrics: () => set({ floatingLyrics: { ...DEFAULT_FLOATING_LYRICS } }),
 
   getEffectiveTheme: () => {
     const { theme } = get();

--- a/packages/shared/src/store/playing-list.test.ts
+++ b/packages/shared/src/store/playing-list.test.ts
@@ -6,23 +6,23 @@
 import { usePlayingListStore } from './playing-list';
 
 function reset() {
-  usePlayingListStore.setState({ favId: '', bvIds: [], current: '', playNext: false });
+  usePlayingListStore.setState({ favId: '', trackIds: [], current: '', playNext: false });
 }
 
 describe('usePlayingListStore', () => {
   beforeEach(reset);
 
   describe('addSingle', () => {
-    it('追加新 bvid 到末尾', () => {
+    it('追加新 trackId 到末尾', () => {
       usePlayingListStore.getState().addSingle('BV1');
-      expect(usePlayingListStore.getState().bvIds).toEqual(['BV1']);
+      expect(usePlayingListStore.getState().trackIds).toEqual(['BV1']);
       expect(usePlayingListStore.getState().playNext).toBe(false);
     });
 
-    it('已存在的 bvid 不重复追加', () => {
-      usePlayingListStore.setState({ bvIds: ['BV1'] });
+    it('已存在的 trackId 不重复追加', () => {
+      usePlayingListStore.setState({ trackIds: ['BV1'] });
       usePlayingListStore.getState().addSingle('BV1');
-      expect(usePlayingListStore.getState().bvIds).toEqual(['BV1']);
+      expect(usePlayingListStore.getState().trackIds).toEqual(['BV1']);
     });
 
     it('playNow=true 同步设置 current 与 playNext', () => {
@@ -34,11 +34,11 @@ describe('usePlayingListStore', () => {
   });
 
   describe('setPlaylist', () => {
-    it('设置完整播放列表，current 默认为首个 bvid', () => {
+    it('设置完整播放列表，current 默认为首个 trackId', () => {
       usePlayingListStore.getState().setPlaylist('main', ['A', 'B', 'C']);
       const s = usePlayingListStore.getState();
       expect(s.favId).toBe('main');
-      expect(s.bvIds).toEqual(['A', 'B', 'C']);
+      expect(s.trackIds).toEqual(['A', 'B', 'C']);
       expect(s.current).toBe('A');
       expect(s.playNext).toBe(false);
     });
@@ -58,35 +58,35 @@ describe('usePlayingListStore', () => {
 
   describe('removeItem', () => {
     it('删除非当前曲目：只移除，不切歌', () => {
-      usePlayingListStore.setState({ bvIds: ['A', 'B', 'C'], current: 'A' });
+      usePlayingListStore.setState({ trackIds: ['A', 'B', 'C'], current: 'A' });
       usePlayingListStore.getState().removeItem('B');
       const s = usePlayingListStore.getState();
-      expect(s.bvIds).toEqual(['A', 'C']);
+      expect(s.trackIds).toEqual(['A', 'C']);
       expect(s.current).toBe('A');
       expect(s.playNext).toBe(false);
     });
 
     it('删除当前曲目：自动切到原位置（位置不变取下一个）', () => {
-      usePlayingListStore.setState({ bvIds: ['A', 'B', 'C'], current: 'B' });
+      usePlayingListStore.setState({ trackIds: ['A', 'B', 'C'], current: 'B' });
       usePlayingListStore.getState().removeItem('B');
       const s = usePlayingListStore.getState();
-      expect(s.bvIds).toEqual(['A', 'C']);
+      expect(s.trackIds).toEqual(['A', 'C']);
       expect(s.current).toBe('C');
       expect(s.playNext).toBe(true);
     });
 
     it('删除最后一首当前曲目：current fallback 到末尾', () => {
-      usePlayingListStore.setState({ bvIds: ['A', 'B'], current: 'B' });
+      usePlayingListStore.setState({ trackIds: ['A', 'B'], current: 'B' });
       usePlayingListStore.getState().removeItem('B');
       const s = usePlayingListStore.getState();
       expect(s.current).toBe('A');
     });
 
     it('删空列表：current 为空字符串', () => {
-      usePlayingListStore.setState({ bvIds: ['A'], current: 'A' });
+      usePlayingListStore.setState({ trackIds: ['A'], current: 'A' });
       usePlayingListStore.getState().removeItem('A');
       const s = usePlayingListStore.getState();
-      expect(s.bvIds).toEqual([]);
+      expect(s.trackIds).toEqual([]);
       expect(s.current).toBe('');
     });
   });
@@ -95,14 +95,14 @@ describe('usePlayingListStore', () => {
     it('清空所有字段', () => {
       usePlayingListStore.setState({
         favId: 'm',
-        bvIds: ['A'],
+        trackIds: ['A'],
         current: 'A',
         playNext: true,
       });
       usePlayingListStore.getState().clearPlaylist();
       expect(usePlayingListStore.getState()).toMatchObject({
         favId: '',
-        bvIds: [],
+        trackIds: [],
         current: '',
         playNext: false,
       });
@@ -111,7 +111,7 @@ describe('usePlayingListStore', () => {
 
   describe('updateCurrentPlaying', () => {
     beforeEach(() => {
-      usePlayingListStore.setState({ bvIds: ['A', 'B', 'C'], current: 'A' });
+      usePlayingListStore.setState({ trackIds: ['A', 'B', 'C'], current: 'A' });
     });
 
     it('切到指定 index 并触发 playNext', () => {
@@ -145,7 +145,7 @@ describe('usePlayingListStore', () => {
 
   describe('getNextIndex', () => {
     beforeEach(() => {
-      usePlayingListStore.setState({ bvIds: ['A', 'B', 'C'], current: 'B' });
+      usePlayingListStore.setState({ trackIds: ['A', 'B', 'C'], current: 'B' });
     });
 
     it('loop 模式：循环到下一首', () => {
@@ -168,14 +168,14 @@ describe('usePlayingListStore', () => {
     });
 
     it('空列表：返回 -1', () => {
-      usePlayingListStore.setState({ bvIds: [], current: '' });
+      usePlayingListStore.setState({ trackIds: [], current: '' });
       expect(usePlayingListStore.getState().getNextIndex('loop')).toBe(-1);
     });
   });
 
   describe('getPrevIndex', () => {
     beforeEach(() => {
-      usePlayingListStore.setState({ bvIds: ['A', 'B', 'C'], current: 'B' });
+      usePlayingListStore.setState({ trackIds: ['A', 'B', 'C'], current: 'B' });
     });
 
     it('loop 模式：上一首', () => {
@@ -188,7 +188,7 @@ describe('usePlayingListStore', () => {
     });
 
     it('空列表：返回 -1', () => {
-      usePlayingListStore.setState({ bvIds: [], current: '' });
+      usePlayingListStore.setState({ trackIds: [], current: '' });
       expect(usePlayingListStore.getState().getPrevIndex('loop')).toBe(-1);
     });
   });

--- a/packages/shared/src/store/playing-list.ts
+++ b/packages/shared/src/store/playing-list.ts
@@ -1,16 +1,26 @@
 import { create } from 'zustand';
 import type { LoopMode } from '../types';
 
+/**
+ * 播放队列
+ *
+ * 队列元素称为 TrackId，可为：
+ * - 纯 bvid（如 'BV1aB4y1k7Yx'）→ 按该投稿"默认 P / P1"播放
+ * - bvid:p<n>（如 'BV1aB4y1k7Yx:p3'）→ 显式锁定该 P
+ *
+ * 自 B2 起字段从 bvIds 重命名为 trackIds，更精确表达"队列条目可能含分 P 标识"。
+ * 持久化 hydrate 路径仍兼容旧 bvIds 字段（见 middleware/persist.ts）。
+ */
 interface PlayingListState {
   favId: string;
-  bvIds: string[];
+  trackIds: string[];
   current: string;
   /** 上一个动作希望立即开始播放（由 SPlayer 消费后通过 clearPlayNext 复位） */
   playNext: boolean;
 
-  addSingle: (bvId: string, playNow?: boolean) => void;
-  setPlaylist: (favId: string, bvIds: string[], current?: string, playNow?: boolean) => void;
-  removeItem: (bvId: string) => void;
+  addSingle: (trackId: string, playNow?: boolean) => void;
+  setPlaylist: (favId: string, trackIds: string[], current?: string, playNow?: boolean) => void;
+  removeItem: (trackId: string) => void;
   clearPlaylist: () => void;
   updateCurrentPlaying: (index: number, playNext?: boolean) => void;
   clearPlayNext: () => void;
@@ -20,44 +30,48 @@ interface PlayingListState {
 
 export const usePlayingListStore = create<PlayingListState>((set, get) => ({
   favId: '',
-  bvIds: [],
+  trackIds: [],
   current: '',
   playNext: false,
 
-  addSingle: (bvId, playNow = false) =>
+  addSingle: (trackId, playNow = false) =>
     set((state) => {
-      const bvIds = state.bvIds.includes(bvId) ? state.bvIds : [...state.bvIds, bvId];
+      const trackIds = state.trackIds.includes(trackId)
+        ? state.trackIds
+        : [...state.trackIds, trackId];
       return {
-        bvIds,
-        ...(playNow ? { current: bvId, playNext: true } : {}),
+        trackIds,
+        ...(playNow ? { current: trackId, playNext: true } : {}),
       };
     }),
 
-  setPlaylist: (favId, bvIds, current, playNow = false) =>
+  setPlaylist: (favId, trackIds, current, playNow = false) =>
     set({
       favId,
-      bvIds,
-      current: current || bvIds[0] || '',
+      trackIds,
+      current: current || trackIds[0] || '',
       playNext: playNow,
     }),
 
-  removeItem: (bvId) =>
+  removeItem: (trackId) =>
     set((state) => {
-      const bvIds = state.bvIds.filter((id) => id !== bvId);
-      const isCurrent = state.current === bvId;
-      const currentIndex = state.bvIds.indexOf(bvId);
+      const trackIds = state.trackIds.filter((id) => id !== trackId);
+      const isCurrent = state.current === trackId;
+      const currentIndex = state.trackIds.indexOf(trackId);
       return {
-        bvIds,
-        current: isCurrent ? bvIds[Math.min(currentIndex, bvIds.length - 1)] || '' : state.current,
+        trackIds,
+        current: isCurrent
+          ? trackIds[Math.min(currentIndex, trackIds.length - 1)] || ''
+          : state.current,
         playNext: isCurrent,
       };
     }),
 
-  clearPlaylist: () => set({ favId: '', bvIds: [], current: '', playNext: false }),
+  clearPlaylist: () => set({ favId: '', trackIds: [], current: '', playNext: false }),
 
   updateCurrentPlaying: (index, playNext = true) =>
     set((state) => {
-      const next = state.bvIds[index] || '';
+      const next = state.trackIds[index] || '';
       if (next === state.current && !playNext) return state;
       return { current: next, playNext };
     }),
@@ -65,20 +79,20 @@ export const usePlayingListStore = create<PlayingListState>((set, get) => ({
   clearPlayNext: () => set({ playNext: false }),
 
   getNextIndex: (loopMode) => {
-    const { bvIds, current } = get();
-    if (bvIds.length === 0) return -1;
-    const currentIndex = bvIds.indexOf(current);
+    const { trackIds, current } = get();
+    if (trackIds.length === 0) return -1;
+    const currentIndex = trackIds.indexOf(current);
     if (loopMode === 'single') return currentIndex;
-    if (loopMode === 'random') return Math.floor(Math.random() * bvIds.length);
-    return (currentIndex + 1) % bvIds.length;
+    if (loopMode === 'random') return Math.floor(Math.random() * trackIds.length);
+    return (currentIndex + 1) % trackIds.length;
   },
 
   getPrevIndex: (loopMode) => {
-    const { bvIds, current } = get();
-    if (bvIds.length === 0) return -1;
-    const currentIndex = bvIds.indexOf(current);
+    const { trackIds, current } = get();
+    if (trackIds.length === 0) return -1;
+    const currentIndex = trackIds.indexOf(current);
     if (loopMode === 'single') return currentIndex;
-    if (loopMode === 'random') return Math.floor(Math.random() * bvIds.length);
-    return (currentIndex - 1 + bvIds.length) % bvIds.length;
+    if (loopMode === 'random') return Math.floor(Math.random() * trackIds.length);
+    return (currentIndex - 1 + trackIds.length) % trackIds.length;
   },
 }));

--- a/packages/shared/src/store/video-page-pref.test.ts
+++ b/packages/shared/src/store/video-page-pref.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useVideoPagePrefStore } from './video-page-pref';
+
+describe('useVideoPagePrefStore', () => {
+  beforeEach(() => {
+    useVideoPagePrefStore.setState({ defaultPage: {} });
+  });
+
+  it('setDefaultPage 写入 page >= 2', () => {
+    useVideoPagePrefStore.getState().setDefaultPage('BV1aB4y1k7Yx', 3);
+    expect(useVideoPagePrefStore.getState().defaultPage['BV1aB4y1k7Yx']).toBe(3);
+  });
+
+  it('setDefaultPage(bvid, 1) 自动删除 key', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { BV1aB4y1k7Yx: 3 } });
+    useVideoPagePrefStore.getState().setDefaultPage('BV1aB4y1k7Yx', 1);
+    expect('BV1aB4y1k7Yx' in useVideoPagePrefStore.getState().defaultPage).toBe(false);
+  });
+
+  it('setDefaultPage(bvid, 0) / 负数 / 非整数 → 视为清空', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { BV1aB4y1k7Yx: 3 } });
+    useVideoPagePrefStore.getState().setDefaultPage('BV1aB4y1k7Yx', 0);
+    expect('BV1aB4y1k7Yx' in useVideoPagePrefStore.getState().defaultPage).toBe(false);
+
+    useVideoPagePrefStore.setState({ defaultPage: { BV1aB4y1k7Yx: 3 } });
+    useVideoPagePrefStore.getState().setDefaultPage('BV1aB4y1k7Yx', -1);
+    expect('BV1aB4y1k7Yx' in useVideoPagePrefStore.getState().defaultPage).toBe(false);
+
+    useVideoPagePrefStore.setState({ defaultPage: { BV1aB4y1k7Yx: 3 } });
+    useVideoPagePrefStore.getState().setDefaultPage('BV1aB4y1k7Yx', 2.5);
+    expect('BV1aB4y1k7Yx' in useVideoPagePrefStore.getState().defaultPage).toBe(false);
+  });
+
+  it('setDefaultPage(bvid, 1) 对未存在的 key 无副作用', () => {
+    useVideoPagePrefStore.getState().setDefaultPage('BV1aB4y1k7Yx', 1);
+    expect(useVideoPagePrefStore.getState().defaultPage).toEqual({});
+  });
+
+  it('空 bvid 不写入', () => {
+    useVideoPagePrefStore.getState().setDefaultPage('', 3);
+    expect(useVideoPagePrefStore.getState().defaultPage).toEqual({});
+  });
+
+  it('clearDefaultPage 删除指定 key', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { BV1: 3, BV2: 5 } });
+    useVideoPagePrefStore.getState().clearDefaultPage('BV1');
+    expect(useVideoPagePrefStore.getState().defaultPage).toEqual({ BV2: 5 });
+  });
+
+  it('clearDefaultPage 对不存在的 key 不修改 state（引用稳定）', () => {
+    const before = { BV1: 3 };
+    useVideoPagePrefStore.setState({ defaultPage: before });
+    useVideoPagePrefStore.getState().clearDefaultPage('BVX');
+    expect(useVideoPagePrefStore.getState().defaultPage).toBe(before);
+  });
+
+  it('getDefaultPage 缺省返回 1', () => {
+    expect(useVideoPagePrefStore.getState().getDefaultPage('BVX')).toBe(1);
+  });
+
+  it('getDefaultPage 命中返回 page', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { BV1: 7 } });
+    expect(useVideoPagePrefStore.getState().getDefaultPage('BV1')).toBe(7);
+  });
+});

--- a/packages/shared/src/store/video-page-pref.ts
+++ b/packages/shared/src/store/video-page-pref.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand';
+
+/**
+ * 多 P 视频的"默认 P"用户偏好
+ *
+ * 仅记录"用户主动选过的非默认 P"（page >= 2）；page === 1 视为无偏好并自动删除 key，
+ * 避免长期累积大量等价于默认值的 key 撑大 player_data。
+ *
+ * 仅作用于：
+ * - UPLOADER / BILI_FAV 列表中纯 bvid 条目的播放
+ * - 自定义歌单 / 我的收藏中纯 bvid 条目的播放
+ *
+ * 不影响：
+ * - 显式 `bvid:p<n>` TrackId（它本身就指定了 P）
+ */
+interface VideoPagePrefState {
+  /** bvid → 默认 P（数值范围 >= 2） */
+  defaultPage: Record<string, number>;
+
+  /** 设置默认 P；传入 page <= 1 视为清空（删 key） */
+  setDefaultPage: (bvid: string, page: number) => void;
+  /** 清除某 bvid 的默认 P 设置 */
+  clearDefaultPage: (bvid: string) => void;
+  /** 读取默认 P；无设置时返回 1 */
+  getDefaultPage: (bvid: string) => number;
+}
+
+export const useVideoPagePrefStore = create<VideoPagePrefState>((set, get) => ({
+  defaultPage: {},
+
+  setDefaultPage: (bvid, page) => {
+    if (!bvid) return;
+    if (!Number.isInteger(page) || page <= 1) {
+      const existing = get().defaultPage;
+      if (!(bvid in existing)) return;
+      const next = { ...existing };
+      delete next[bvid];
+      set({ defaultPage: next });
+      return;
+    }
+    set((state) => ({
+      defaultPage: { ...state.defaultPage, [bvid]: page },
+    }));
+  },
+
+  clearDefaultPage: (bvid) => {
+    const existing = get().defaultPage;
+    if (!(bvid in existing)) return;
+    const next = { ...existing };
+    delete next[bvid];
+    set({ defaultPage: next });
+  },
+
+  getDefaultPage: (bvid) => {
+    return get().defaultPage[bvid] ?? 1;
+  },
+}));

--- a/packages/shared/src/types/bilibili.ts
+++ b/packages/shared/src/types/bilibili.ts
@@ -12,6 +12,18 @@ export interface BilibiliUserInfo {
   };
 }
 
+/** B 站视频分 P 元数据（view 接口 pages[] 子集） */
+export interface BilibiliVideoPage {
+  /** 该 P 的 cid（取流必传） */
+  cid: number;
+  /** 该 P 的序号，从 1 开始 */
+  page: number;
+  /** 该 P 的标题 */
+  part: string;
+  /** 该 P 的时长，单位秒 */
+  duration: number;
+}
+
 /** B 站视频实体 */
 export interface BilibiliVideo {
   aid: number;
@@ -27,7 +39,12 @@ export interface BilibiliVideo {
   author: string;
   description: string;
   mid?: number;
+  /** 视频 1P 的 cid（便于不查 pages 的快速场景使用） */
   cid?: number;
+  /** 分 P 总数；缺失视为 1 */
+  videos?: number;
+  /** 分 P 列表（view 模式入库时填充；列表 / 收藏夹模式可能缺失） */
+  pages?: BilibiliVideoPage[];
 }
 
 /** UP 主空间信息（/x/space/wbi/acc/info 响应字段拾取） */

--- a/packages/shared/src/types/playlist.ts
+++ b/packages/shared/src/types/playlist.ts
@@ -23,6 +23,44 @@ export interface FavListItem {
 /** 循环模式 */
 export type LoopMode = 'single' | 'loop' | 'random';
 
+/** 悬浮歌词水平对齐 */
+export type FloatingLyricsAlign = 'left' | 'center' | 'right';
+/** 悬浮歌词字重 */
+export type FloatingLyricsWeight = 'normal' | 'bold';
+/** 悬浮歌词字体族 */
+export type FloatingLyricsFamily = 'sans' | 'serif' | 'mono';
+/** 悬浮歌词预设文字色（'' === 'primary'，跟随主色） */
+export type FloatingLyricsColor = '' | 'primary' | 'white' | 'black' | 'muted';
+
+/** 悬浮歌词配置（位于 PlayerProfile.floatingLyrics） */
+export interface FloatingLyricsConfig {
+  /** 是否启用（默认 true） */
+  enabled: boolean;
+  /** 字号 px，12-32 */
+  fontSize: number;
+  fontWeight: FloatingLyricsWeight;
+  fontFamily: FloatingLyricsFamily;
+  textAlign: FloatingLyricsAlign;
+  /** 距 footer 顶边的垂直偏移 px，16-64 */
+  verticalOffset: number;
+  /** 预设色键；'' 视同 'primary' */
+  textColor: FloatingLyricsColor;
+  /** 背景透明度 0-1 */
+  bgOpacity: number;
+}
+
+/** 悬浮歌词默认值（首次启动 / 恢复默认时使用） */
+export const DEFAULT_FLOATING_LYRICS: FloatingLyricsConfig = {
+  enabled: true,
+  fontSize: 20,
+  fontWeight: 'normal',
+  fontFamily: 'sans',
+  textAlign: 'center',
+  verticalOffset: 16,
+  textColor: '',
+  bgOpacity: 0.8,
+};
+
 /** 播放器全局配置 */
 export interface PlayerProfile {
   theme: 'light' | 'dark' | 'auto';
@@ -45,6 +83,8 @@ export interface PlayerProfile {
    * 关闭时：多 P 投稿与单 P 投稿表现一致——一首结束即切下一首。
    */
   autoPlayNextPage: boolean;
+  /** 悬浮歌词（footer 上方歌词条）的样式与开关 */
+  floatingLyrics: FloatingLyricsConfig;
 }
 
 /** 默认强调色（与 packages/web/src/styles/globals.css 中 --primary 一致；#FF8FA7 中粉） */

--- a/packages/shared/src/types/playlist.ts
+++ b/packages/shared/src/types/playlist.ts
@@ -36,6 +36,15 @@ export interface PlayerProfile {
    * 空字符串 / undefined 表示不覆盖（用 globals.css 默认值）。
    */
   primaryColor: string;
+  /**
+   * 多 P 投稿连续播放（实验性，默认关闭）。
+   *
+   * 开启后：播放纯 bvid（非显式 :p<n>）TrackId 且为多 P 投稿时，
+   * onend 触发会先尝试切到下一 P，直到所有 P 播完才走 next() 切下一个 TrackId。
+   *
+   * 关闭时：多 P 投稿与单 P 投稿表现一致——一首结束即切下一首。
+   */
+  autoPlayNextPage: boolean;
 }
 
 /** 默认强调色（与 packages/web/src/styles/globals.css 中 --primary 一致；#FF8FA7 中粉） */

--- a/packages/shared/src/utils/bilibili.test.ts
+++ b/packages/shared/src/utils/bilibili.test.ts
@@ -2,6 +2,7 @@ import {
   bilibiliThumbUrl,
   formatNumber10K,
   getBilibiliMidByURL,
+  pickVideosFields,
   urlPrefixFixed,
 } from './bilibili';
 
@@ -97,5 +98,84 @@ describe('A4: bilibiliThumbUrl', () => {
     expect(bilibiliThumbUrl('https://biliimg.com/foo.png', 64, 64)).toBe(
       'https://biliimg.com/foo.png@64w_64h_1c.webp',
     );
+  });
+});
+
+describe('A4: pickVideosFields(view) 映射 pages/videos', () => {
+  const baseViewItem = {
+    bvid: 'BV1aB4y1k7Yx',
+    aid: 12345,
+    pic: 'https://x.com/p.jpg',
+    title: 't',
+    sub_title: '',
+    is_union_video: false,
+    ctime: 100,
+    duration: '3:00',
+    stat: { view: 9, reply: 1 },
+    owner: { name: 'up', mid: 7 },
+    desc: 'd',
+    cid: 99,
+  };
+
+  it('单 P 投稿：videos=1, pages 长度 1', () => {
+    const mapped = pickVideosFields(
+      {
+        ...baseViewItem,
+        videos: 1,
+        pages: [{ cid: 99, page: 1, part: '', duration: 180 }],
+      } as never,
+      'view',
+    );
+    expect(mapped[0]?.videos).toBe(1);
+    expect(mapped[0]?.pages).toEqual([{ cid: 99, page: 1, part: '', duration: 180 }]);
+  });
+
+  it('多 P 投稿：videos=N, pages 完整映射', () => {
+    const mapped = pickVideosFields(
+      {
+        ...baseViewItem,
+        videos: 3,
+        pages: [
+          { cid: 100, page: 1, part: 'Intro', duration: 60 },
+          { cid: 101, page: 2, part: 'Verse', duration: 90 },
+          { cid: 102, page: 3, part: 'Outro', duration: 30 },
+        ],
+      } as never,
+      'view',
+    );
+    expect(mapped[0]?.videos).toBe(3);
+    expect(mapped[0]?.pages).toHaveLength(3);
+    expect(mapped[0]?.pages?.[1]).toEqual({ cid: 101, page: 2, part: 'Verse', duration: 90 });
+  });
+
+  it('pages 缺失 → pages 字段为 undefined', () => {
+    const mapped = pickVideosFields({ ...baseViewItem }, 'view');
+    expect(mapped[0]?.pages).toBeUndefined();
+  });
+
+  it('pages[] 中非法项被过滤（缺 cid 或非数字 page）', () => {
+    const mapped = pickVideosFields(
+      {
+        ...baseViewItem,
+        videos: 2,
+        pages: [
+          { cid: 100, page: 1, part: 'ok', duration: 60 },
+          { page: 2, part: 'no-cid', duration: 30 },
+          { cid: 102, page: 'three' as never, part: 'bad-page', duration: 30 },
+          null,
+        ],
+      } as never,
+      'view',
+    );
+    expect(mapped[0]?.pages).toEqual([{ cid: 100, page: 1, part: 'ok', duration: 60 }]);
+  });
+
+  it('default 模式不触发 view 映射（不动 pages 字段）', () => {
+    const mapped = pickVideosFields(
+      { bvid: 'BV1', videos: 99, pages: [{ cid: 1, page: 1, part: '', duration: 0 }] } as never,
+      'default',
+    );
+    // default 模式直接透传，无映射规则；pages 透传不动
+    expect((mapped[0] as { videos?: number }).videos).toBe(99);
   });
 });

--- a/packages/shared/src/utils/bilibili.ts
+++ b/packages/shared/src/utils/bilibili.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import 'dayjs/locale/zh-cn';
 import relativeTime from 'dayjs/plugin/relativeTime';
-import type { BilibiliVideo } from '../types';
+import type { BilibiliVideo, BilibiliVideoPage } from '../types';
 
 dayjs.extend(relativeTime);
 dayjs.locale('zh-cn');
@@ -38,6 +38,24 @@ type PickMode = 'default' | 'fav_folder' | 'view';
 type RawItem = Record<string, unknown> & { bvid: string };
 type Mapped = Partial<BilibiliVideo> & { bvid: string };
 
+/** view.pages[] 原始项 → BilibiliVideoPage（裁剪到 cid/page/part/duration 四字段） */
+function mapPagesField(raw: unknown): BilibiliVideoPage[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: BilibiliVideoPage[] = [];
+  for (const p of raw) {
+    if (!p || typeof p !== 'object') continue;
+    const obj = p as { cid?: number; page?: number; part?: string; duration?: number };
+    if (typeof obj.cid !== 'number' || typeof obj.page !== 'number') continue;
+    out.push({
+      cid: obj.cid,
+      page: obj.page,
+      part: typeof obj.part === 'string' ? obj.part : '',
+      duration: typeof obj.duration === 'number' ? obj.duration : 0,
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
 function mapViewItem(i: RawItem): Mapped {
   const stat = (i.stat ?? {}) as { view?: number; reply?: number };
   const owner = (i.owner ?? {}) as { name?: string; mid?: number };
@@ -56,6 +74,9 @@ function mapViewItem(i: RawItem): Mapped {
     mid: owner.mid,
     // view 接口返回单 P 的 cid；fetchMusicUrl 走 playurl 时可直接复用，省一次 view 调用
     cid: typeof i.cid === 'number' ? (i.cid as number) : undefined,
+    // 分 P 元数据：view 接口返回 videos（总数）+ pages[]（每 P cid/page/part/duration）
+    videos: typeof i.videos === 'number' ? (i.videos as number) : undefined,
+    pages: mapPagesField(i.pages),
     description: (i.desc ?? i.description) as string,
   };
 }

--- a/packages/shared/src/utils/import-export.test.ts
+++ b/packages/shared/src/utils/import-export.test.ts
@@ -169,6 +169,43 @@ describe('parseImportData', () => {
     });
     expect(out!.favList.map((it) => it.id)).toEqual(['A']);
   });
+
+  it('favorites：v2 文件提取 entries + favoriteCount', () => {
+    const out = parseImportData({
+      version: '2',
+      fav_list: { list: [] },
+      favorites: { entries: { BV1: 100, BV2: 200 } },
+    });
+    expect(out!.payload.favorites.entries).toEqual({ BV1: 100, BV2: 200 });
+    expect(out!.favoriteCount).toBe(2);
+  });
+
+  it('favorites：缺失字段（v1 文件 / 旧 v2 文件）→ 空对象兜底', () => {
+    const out = parseImportData({
+      version: '2',
+      fav_list: { list: [] },
+    });
+    expect(out!.payload.favorites.entries).toEqual({});
+    expect(out!.favoriteCount).toBe(0);
+  });
+
+  it('favorites：非有限正数 ts 被过滤（字符串、NaN、负数、Infinity）', () => {
+    const out = parseImportData({
+      version: '2',
+      fav_list: { list: [] },
+      favorites: {
+        entries: {
+          BV1: 100,
+          BV2: 'not-a-number',
+          BV3: NaN,
+          BV4: -1,
+          BV5: Infinity,
+          BV6: 0,
+        },
+      },
+    });
+    expect(out!.payload.favorites.entries).toEqual({ BV1: 100, BV6: 0 });
+  });
 });
 
 describe('buildMerged', () => {
@@ -176,6 +213,7 @@ describe('buildMerged', () => {
     fav_list: { list: [v2Item('A', 'imported-A'), v2Item('B', 'imported-B')] },
     lyrics: { lyricMaps: { BV1: { bvid: 'BV1' }, BV2: { bvid: 'BV2' } } as never },
     bili_videos: { entities: {}, ids: [] },
+    favorites: { entries: {} },
   };
 
   it('skip：仅添加 current 不存在的项；A 保持现有内容', () => {
@@ -219,6 +257,7 @@ describe('buildMerged', () => {
       },
       lyrics: { lyricMaps: {} },
       bili_videos: { entities: {}, ids: [] },
+      favorites: { entries: {} },
     };
     const out = buildMerged(
       {
@@ -260,6 +299,7 @@ describe('buildMerged', () => {
       },
       lyrics: { lyricMaps: {} },
       bili_videos: { entities: {}, ids: [] },
+      favorites: { entries: {} },
     };
     const out = buildMerged(
       {
@@ -367,6 +407,7 @@ describe('buildMerged', () => {
         } as never,
         ids: ['BV1', 'BV2'],
       },
+      favorites: { entries: {} },
     };
     const currentVideos = {
       bili_videos: {
@@ -387,5 +428,46 @@ describe('buildMerged', () => {
     expect(
       (replaceOut.bili_videos.entities as never as Record<string, { title?: string }>).BV1.title,
     ).toBe('current-1');
+  });
+
+  it('favorites：union 合并；同 bvid 取 Math.min(ts) 保留首次喜欢', () => {
+    const payload = {
+      fav_list: { list: [] },
+      lyrics: { lyricMaps: {} },
+      bili_videos: { entities: {}, ids: [] },
+      favorites: { entries: { BV1: 200, BV2: 500 } },
+    };
+    const out = buildMerged({ favorites: { entries: { BV1: 100, BV3: 300 } } }, payload, 'skip');
+    // BV1：双方都有，取 min(100, 200) = 100
+    // BV2：仅 imported，追加
+    // BV3：仅 current，保留
+    expect(out.favorites.entries).toEqual({ BV1: 100, BV2: 500, BV3: 300 });
+  });
+
+  it('favorites：skip / replace 模式行为完全一致（硬约束 union+min）', () => {
+    const payload = {
+      fav_list: { list: [] },
+      lyrics: { lyricMaps: {} },
+      bili_videos: { entities: {}, ids: [] },
+      favorites: { entries: { BV1: 50, BV2: 600 } },
+    };
+    const current = { favorites: { entries: { BV1: 100 } } };
+
+    const skipOut = buildMerged(current, payload, 'skip');
+    const replaceOut = buildMerged(current, payload, 'replace');
+    expect(skipOut.favorites.entries).toEqual(replaceOut.favorites.entries);
+    // 双方 BV1：min(100, 50) = 50
+    expect(skipOut.favorites.entries?.BV1).toBe(50);
+  });
+
+  it('favorites：current 缺失（首次导入）→ 完全采纳 imported', () => {
+    const payload = {
+      fav_list: { list: [] },
+      lyrics: { lyricMaps: {} },
+      bili_videos: { entities: {}, ids: [] },
+      favorites: { entries: { BV1: 100, BV2: 200 } },
+    };
+    const out = buildMerged({}, payload, 'skip');
+    expect(out.favorites.entries).toEqual({ BV1: 100, BV2: 200 });
   });
 });

--- a/packages/shared/src/utils/import-export.ts
+++ b/packages/shared/src/utils/import-export.ts
@@ -16,6 +16,7 @@ import { FavListType, type BilibiliVideo, type FavListItem, type LyricEntry } fr
 import type {
   PersistedBilibiliVideosShape,
   PersistedFavListShape,
+  PersistedFavoritesShape,
   PersistedLyricsShape,
 } from '../store/persisted-types';
 
@@ -30,6 +31,8 @@ export interface ImportPayload {
   lyrics: PersistedLyricsShape;
   /** 视频元数据缓存：自定义歌单(type=0)的曲目展示依赖该字段从 bvid 反查标题/封面 */
   bili_videos: PersistedBilibiliVideosShape;
+  /** 系统级「我的收藏」：bvid → 收藏时间戳；v1 文件无此字段时为空对象 */
+  favorites: PersistedFavoritesShape;
 }
 
 export interface ImportSummary {
@@ -40,6 +43,8 @@ export interface ImportSummary {
   lyricCount: number;
   /** bili_videos.entities 的 key 数（视频元数据条数） */
   videoCount: number;
+  /** favorites.entries 的 key 数（我的收藏条目总数） */
+  favoriteCount: number;
 }
 
 export interface ParsedImport extends ImportSummary {
@@ -141,21 +146,34 @@ export function parseImportData(input: unknown): ParsedImport | null {
     : Object.keys(entities);
   const videoCount = Object.keys(entities).length;
 
+  // 提取 favorites.entries（v1 文件无此字段，自然兜底空对象；非有限正数 ts 过滤）
+  const favoritesRaw = isPlainObject(input.favorites) ? input.favorites : {};
+  const entriesRaw = isPlainObject(favoritesRaw.entries) ? favoritesRaw.entries : {};
+  const favoriteEntries: Record<string, number> = {};
+  for (const [bvid, ts] of Object.entries(entriesRaw)) {
+    if (typeof ts === 'number' && Number.isFinite(ts) && ts >= 0) {
+      favoriteEntries[bvid] = ts;
+    }
+  }
+  const favoriteCount = Object.keys(favoriteEntries).length;
+
   return {
     version,
     favList,
     lyricCount,
     videoCount,
+    favoriteCount,
     payload: {
       fav_list: { list: favList },
       lyrics: { lyricMaps },
       bili_videos: { entities, ids },
+      favorites: { entries: favoriteEntries },
     },
   };
 }
 
 /**
- * 按合并模式构造写回 storage 的 fav_list / lyrics / bili_videos
+ * 按合并模式构造写回 storage 的 fav_list / lyrics / bili_videos / favorites
  *
  * - mode='skip'：勾选项中已存在同 id 的歌单 → 跳过（保护现有）；新 id → 追加
  * - mode='replace'：勾选项中 type=0 的同 id → 用导入版本覆盖；新 id → 追加
@@ -164,13 +182,15 @@ export function parseImportData(input: unknown): ParsedImport | null {
  * 1. 永远不删除 current 中"导入文件没出现"的项
  * 2. fav_list 中 type=1/2（B 站收藏夹/UP 主）即使在 replace 模式下也始终 append-only，
  *    因为 v1 / 旧导出的 bv_ids 不可信，覆盖会洗掉用户在 v2 已手动刷新过的内容
+ * 3. favorites 永远 union；同 bvid 取 Math.min(ts)，保留"首次喜欢"的时间戳；
+ *    不区分 mode（避免误删用户收藏，硬约束）
  *
  * selectedFavIds：仅作用于 fav_list；undefined 时视为全选。
  * lyrics：始终全量按 mode 合并（无 UI 勾选；replace 用导入覆盖同 bvid，skip 仅追加新 bvid）。
  * bili_videos：永远走"取并集，已有不动"语义（视频元数据缓存，不区分模式）；
  *   自定义歌单(type=0)依赖该字段从 bvid 反查标题/封面，不导入会导致 UI 显示空列表。
  *
- * 注意：本函数仅返回 fav_list / lyrics / bili_videos 三个 key 的新值；调用方负责将其他
+ * 注意：本函数仅返回 fav_list / lyrics / bili_videos / favorites 四个 key 的新值；调用方负责将其他
  * EXPORT_KEYS（playing_list / ui_profile / bili_user_videos）与 cloud_service / music_url_cache
  * 等"不导入项"原样保留。
  */
@@ -179,6 +199,7 @@ export function buildMerged(
     fav_list?: PersistedFavListShape;
     lyrics?: PersistedLyricsShape;
     bili_videos?: PersistedBilibiliVideosShape;
+    favorites?: PersistedFavoritesShape;
   },
   imported: ImportPayload,
   mode: MergeMode,
@@ -187,6 +208,7 @@ export function buildMerged(
   fav_list: PersistedFavListShape;
   lyrics: PersistedLyricsShape;
   bili_videos: PersistedBilibiliVideosShape;
+  favorites: PersistedFavoritesShape;
 } {
   const currentFavList = current.fav_list?.list ?? [];
   const currentLyricMaps = current.lyrics?.lyricMaps ?? {};
@@ -244,9 +266,21 @@ export function buildMerged(
     }
   }
 
+  // favorites 合并：union + Math.min(ts)
+  // - 已有不动，导入新 bvid 追加
+  // - 同 bvid 双方都存在时取较早的 ts（"首次喜欢"语义）
+  // - 不区分 mode：用户收藏不应被覆盖删除
+  const currentFavorites = current.favorites?.entries ?? {};
+  const importedFavorites = imported.favorites.entries ?? {};
+  const mergedFavorites: Record<string, number> = { ...currentFavorites };
+  for (const [bvid, ts] of Object.entries(importedFavorites)) {
+    mergedFavorites[bvid] = bvid in mergedFavorites ? Math.min(mergedFavorites[bvid], ts) : ts;
+  }
+
   return {
     fav_list: { list: mergedFavList },
     lyrics: { lyricMaps: mergedLyricMaps },
     bili_videos: { entities: mergedEntities, ids: mergedIds },
+    favorites: { entries: mergedFavorites },
   };
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './type-guards';
 export * from './cloud-list';
 export * from './version-compare';
 export * from './logger';
+export * from './track-id';

--- a/packages/shared/src/utils/music-url.test.ts
+++ b/packages/shared/src/utils/music-url.test.ts
@@ -149,29 +149,7 @@ describe('A7: fetchMusicUrl 音质降级链', () => {
     expect(mockedPlay).toHaveBeenCalledTimes(2);
   });
 
-  it('cid 已存在 URL 缓存中：跳过 view 接口，直接调 playurl', async () => {
-    // 预置一条命中 cid 但 playUrl 已无效（last_update 设为 0 让 getValid 返回 undefined）的条目
-    useMusicUrlCacheStore.setState({
-      entries: {
-        BV_CID_CACHE: { playUrl: '', cid: 4242, last_update: 0 },
-      },
-    });
-    mockedPlay.mockResolvedValueOnce({
-      dash: { audio: [audioStream(AUDIO_QUALITY.HIGH)] },
-    });
-
-    await fetchMusicUrl('BV_CID_CACHE', 1);
-
-    // view 必须没被调；playurl 接口收到的 cid 来自 store
-    expect(mockedView).not.toHaveBeenCalled();
-    expect(mockedPlay).toHaveBeenCalledTimes(1);
-    const callParams = (mockedPlay.mock.calls[0]?.[0] ?? {}) as {
-      params?: { cid?: number };
-    };
-    expect(callParams.params?.cid).toBe(4242);
-  });
-
-  it('cid 已存在 bili_videos store 中（mapViewItem 拾取）：同样跳过 view', async () => {
+  it('cid 已存在 bili_videos store 中（mapViewItem 拾取）：跳过 view', async () => {
     useBilibiliVideosStore.setState({
       ids: ['BV_VS_CACHE'],
       entities: {
@@ -205,7 +183,7 @@ describe('A7: fetchMusicUrl 音质降级链', () => {
     expect(callParams.params?.cid).toBe(9999);
   });
 
-  it('成功后写入持久化 URL 缓存，且包含 cid', async () => {
+  it('成功后写入持久化 URL 缓存（key=bvid:cid，value 不再含 cid）', async () => {
     mockedView.mockResolvedValueOnce({ aid: 1, cid: 200, bvid: 'BV_PERSIST', desc_v2: [] });
     mockedPlay.mockResolvedValueOnce({
       dash: { audio: [audioStream(AUDIO_QUALITY.HIGH, 'https://cdn.example.com/ok.m4s')] },
@@ -213,10 +191,11 @@ describe('A7: fetchMusicUrl 音质降级链', () => {
 
     await fetchMusicUrl('BV_PERSIST', 1);
 
-    const entry = useMusicUrlCacheStore.getState().entries['BV_PERSIST'];
+    const entry = useMusicUrlCacheStore.getState().entries['BV_PERSIST:200'];
     expect(entry?.playUrl).toBe('https://cdn.example.com/ok.m4s');
-    expect(entry?.cid).toBe(200);
     expect(entry?.last_update).toBeGreaterThan(0);
+    // 旧 key 形态（仅 bvid）不应存在
+    expect(useMusicUrlCacheStore.getState().entries['BV_PERSIST']).toBeUndefined();
   });
 
   it('view→playurl 之间无人为 jitter 延迟（<= 50ms）', async () => {
@@ -231,5 +210,158 @@ describe('A7: fetchMusicUrl 音质降级链', () => {
 
     // v1 早期版本会插入 200-500ms 随机延迟；当前实现移除后两次 mock API 总和应远低于 50ms
     expect(elapsed).toBeLessThan(50);
+  });
+});
+
+describe('B1: fetchMusicUrl page 参数（分 P 支持）', () => {
+  beforeEach(() => {
+    mockedView.mockReset();
+    mockedPlay.mockReset();
+    mockedClick.mockReset().mockResolvedValue({});
+    useMusicUrlCacheStore.setState({ entries: {} });
+    useBilibiliVideosStore.setState({ ids: [], entities: {} });
+  });
+
+  it('多 P 投稿请求 page=2：playurl 拿到第 2 P 的 cid', async () => {
+    mockedView.mockResolvedValueOnce({
+      aid: 100,
+      cid: 1000,
+      bvid: 'BV_MULTI',
+      desc_v2: [],
+      videos: 3,
+      pages: [
+        { cid: 1000, page: 1, part: 'P1', duration: 60 },
+        { cid: 1001, page: 2, part: 'P2', duration: 90 },
+        { cid: 1002, page: 3, part: 'P3', duration: 30 },
+      ],
+    });
+    mockedPlay.mockResolvedValueOnce({
+      dash: { audio: [audioStream(AUDIO_QUALITY.HIGH)] },
+    });
+
+    await fetchMusicUrl('BV_MULTI', 1, 0, undefined, 2);
+
+    const callParams = (mockedPlay.mock.calls[0]?.[0] ?? {}) as { params?: { cid?: number } };
+    expect(callParams.params?.cid).toBe(1001);
+    // 写入 cache 时 key 为 bvid:cid（不是 bvid）
+    expect(useMusicUrlCacheStore.getState().entries['BV_MULTI:1001']?.playUrl).toBeTruthy();
+  });
+
+  it('多 P 投稿请求 page=3：直接从 store.pages 拿 cid，跳过 view', async () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV_HAS_PAGES'],
+      entities: {
+        BV_HAS_PAGES: {
+          aid: 1,
+          bvid: 'BV_HAS_PAGES',
+          created: 0,
+          length: '',
+          pic: '',
+          is_union_video: false,
+          title: '',
+          sub_title: '',
+          play: 0,
+          comment: 0,
+          author: '',
+          description: '',
+          videos: 3,
+          pages: [
+            { cid: 2000, page: 1, part: '', duration: 0 },
+            { cid: 2001, page: 2, part: '', duration: 0 },
+            { cid: 2002, page: 3, part: '', duration: 0 },
+          ],
+        },
+      },
+    });
+    mockedPlay.mockResolvedValueOnce({
+      dash: { audio: [audioStream(AUDIO_QUALITY.HIGH)] },
+    });
+
+    await fetchMusicUrl('BV_HAS_PAGES', 1, 0, undefined, 3);
+
+    expect(mockedView).not.toHaveBeenCalled();
+    const callParams = (mockedPlay.mock.calls[0]?.[0] ?? {}) as { params?: { cid?: number } };
+    expect(callParams.params?.cid).toBe(2002);
+  });
+
+  it('同 bvid 不同 page 的 cache 互不覆盖', async () => {
+    mockedView.mockResolvedValue({
+      aid: 1,
+      cid: 5000,
+      bvid: 'BV_ISO',
+      desc_v2: [],
+      videos: 2,
+      pages: [
+        { cid: 5000, page: 1, part: '', duration: 0 },
+        { cid: 5001, page: 2, part: '', duration: 0 },
+      ],
+    });
+    mockedPlay
+      .mockResolvedValueOnce({
+        dash: { audio: [audioStream(AUDIO_QUALITY.HIGH, 'https://cdn/p1.m4s')] },
+      })
+      .mockResolvedValueOnce({
+        dash: { audio: [audioStream(AUDIO_QUALITY.HIGH, 'https://cdn/p2.m4s')] },
+      });
+
+    const u1 = await fetchMusicUrl('BV_ISO', 1, 0, undefined, 1);
+    const u2 = await fetchMusicUrl('BV_ISO', 1, 0, undefined, 2);
+
+    expect(u1).toBe('https://cdn/p1.m4s');
+    expect(u2).toBe('https://cdn/p2.m4s');
+    expect(useMusicUrlCacheStore.getState().entries['BV_ISO:5000']?.playUrl).toBe(
+      'https://cdn/p1.m4s',
+    );
+    expect(useMusicUrlCacheStore.getState().entries['BV_ISO:5001']?.playUrl).toBe(
+      'https://cdn/p2.m4s',
+    );
+  });
+
+  it('page 非法（0 / 负数 / 非整数）→ 视为 1', async () => {
+    mockedView.mockResolvedValueOnce({
+      aid: 1,
+      cid: 999,
+      bvid: 'BV_BAD_PAGE',
+      desc_v2: [],
+    });
+    mockedPlay.mockResolvedValueOnce({
+      dash: { audio: [audioStream(AUDIO_QUALITY.HIGH)] },
+    });
+
+    await fetchMusicUrl('BV_BAD_PAGE', 1, 0, undefined, 0);
+
+    const callParams = (mockedPlay.mock.calls[0]?.[0] ?? {}) as { params?: { cid?: number } };
+    expect(callParams.params?.cid).toBe(999);
+  });
+
+  it('clickStat 上报 part 为 effective page', async () => {
+    vi.useFakeTimers();
+    mockedView.mockResolvedValueOnce({
+      aid: 7,
+      cid: 70,
+      bvid: 'BV_CLICK',
+      desc_v2: [],
+      videos: 2,
+      pages: [
+        { cid: 70, page: 1, part: '', duration: 0 },
+        { cid: 71, page: 2, part: '', duration: 0 },
+      ],
+    });
+    mockedPlay.mockResolvedValueOnce({
+      dash: { audio: [audioStream(AUDIO_QUALITY.HIGH)] },
+    });
+
+    await fetchMusicUrl('BV_CLICK', 999, 0, undefined, 2);
+    // 触发 setTimeout 内的 clickStat
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(mockedClick).toHaveBeenCalled();
+    const clickArgs = (mockedClick.mock.calls[0]?.[0] ?? {}) as {
+      params?: { w_part?: number };
+      data?: { part?: string };
+    };
+    expect(clickArgs.params?.w_part).toBe(2);
+    expect(clickArgs.data?.part).toBe('2');
+    vi.useRealTimers();
   });
 });

--- a/packages/shared/src/utils/music-url.ts
+++ b/packages/shared/src/utils/music-url.ts
@@ -4,8 +4,10 @@ import { getPlatformBridge } from '../platform';
 import { useRiskControlStore } from '../store/risk-control';
 import { useMusicUrlCacheStore } from '../store/music-url-cache';
 import { useBilibiliVideosStore } from '../store/bilibili-videos';
+import { pickVideosFields } from './bilibili';
 import { timeStampNow } from './format';
 import { logger } from './logger';
+import { buildTrackId } from './track-id';
 import type { DashAudioStream } from '../types';
 import type { VideoViewInfo } from '../api/bilibili/video';
 
@@ -28,10 +30,29 @@ function applyAudioUrlTransformer(url: string): string {
 /** 模拟点击节流：bvid → 上次发送时间（秒） */
 const musicPlayClickTime: Record<string, number> = {};
 /**
- * 同 bvid 并发请求复用同一个 Promise（避免 React strict mode useEffect 双触发或
+ * 同 (bvid, page) 并发请求复用同一个 Promise（避免 React strict mode useEffect 双触发或
  * 上下游 effect 重复调用时，第二次抢到 cached.loading=true 后早返回 '' → goNext 误跳下一首）
  */
 const inflightRequests: Record<string, Promise<string>> = {};
+
+/**
+ * 同 bvid 的 view 接口并发去重（不分 P）：
+ * 同 bvid 不同 P 的并发 fetchMusicUrl 在 view 仍进行中时共享同一个 Promise，
+ * 避免 view 被双调；首次完成后 pages 已入库，后续 P 通过 resolveCachedCid 命中 store。
+ */
+const viewInflightByBvid: Record<string, Promise<unknown>> = {};
+
+function coalesceViewCall(bvId: string): Promise<unknown> {
+  const existing = viewInflightByBvid[bvId];
+  if (existing) return existing;
+  const p = (VideoApi.getVideoViewInfo({ params: { bvid: bvId } }) as Promise<unknown>).finally(
+    () => {
+      delete viewInflightByBvid[bvId];
+    },
+  );
+  viewInflightByBvid[bvId] = p;
+  return p;
+}
 
 /* ========== 错误分类（供调用方决定 toast 文案 / 是否风控对话框） ========== */
 
@@ -195,19 +216,29 @@ function pickPlayableUrl(audioInfo: DashAudioStream | undefined): string {
 }
 
 /**
- * 从已知来源解析 cid，避免 fetchMusicUrl 中重复调 view 接口
+ * 从 bili_videos store 解析指定 page 的 cid，避免 fetchMusicUrl 中重复调 view 接口
  *
- * 优先级：
- * 1. URL 缓存中已存的 cid（上次成功 fetch 时回填）
- * 2. bili_videos store 中 view 模式入库的视频 entity（mapViewItem 拾取的 cid）
+ * 自 A5 起 URL 缓存 key 升级为 `bvid:cid`，缓存不再独立保存 cid；
+ * 因此 cid 解析的唯一来源是 bili_videos store 中 view 模式入库的视频 entity。
  *
- * 取不到（如收藏夹来源 / 历史数据）则返回 undefined，调用方需 fallback 到 view 接口
+ * 优先级（B1 起按 page 解析）：
+ * 1. entity.pages[page-1].cid（A4 之后 view 接口已回填完整 pages）
+ * 2. entity.cid（仅 page=1 时使用 — 是 1P 的便捷字段）
+ *
+ * 取不到（如收藏夹来源 / 历史数据 / 跨 P 但 pages 未入库）则返回 undefined，
+ * 调用方需 fallback 到 view 接口。
  */
-function resolveCachedCid(bvid: string): number | undefined {
-  const fromUrlCache = useMusicUrlCacheStore.getState().entries[bvid]?.cid;
-  if (typeof fromUrlCache === 'number' && fromUrlCache > 0) return fromUrlCache;
-  const fromVideoStore = useBilibiliVideosStore.getState().entities[bvid]?.cid;
-  if (typeof fromVideoStore === 'number' && fromVideoStore > 0) return fromVideoStore;
+function resolveCachedCid(bvid: string, page: number = 1): number | undefined {
+  const entity = useBilibiliVideosStore.getState().entities[bvid];
+  if (!entity) return undefined;
+  const pageEntry = entity.pages?.[page - 1];
+  if (pageEntry && typeof pageEntry.cid === 'number' && pageEntry.cid > 0) {
+    return pageEntry.cid;
+  }
+  // 仅 page=1 可以 fallback 到 entity.cid（顶层 cid 是 1P 的 cid）
+  if (page === 1 && typeof entity.cid === 'number' && entity.cid > 0) {
+    return entity.cid;
+  }
   return undefined;
 }
 
@@ -221,32 +252,60 @@ async function attemptFetchMusicUrl(
   currentUserMid: string | number | undefined,
   attempt: number,
   retryCount: number,
+  page: number,
 ): Promise<
   | { url: string; cid: number; aid?: number; descType?: string | number }
   | { error: FetchMusicUrlError }
 > {
   try {
-    // 优先从已知来源拿 cid（URL 缓存 / bili_videos store），命中则跳过 view 接口
-    let cid = resolveCachedCid(bvId);
+    // 优先从 bili_videos store 拿指定 page 的 cid，命中则跳过 view 接口
+    let cid = resolveCachedCid(bvId, page);
     let aid: number | undefined;
     let descType: string | number | undefined;
 
     if (typeof cid !== 'number') {
-      const viewInfo = (await VideoApi.getVideoViewInfo({
-        params: { bvid: bvId },
-      })) as VideoViewInfo & { cid?: number; aid?: number };
+      // 同 bvid 不同 P 并发：若第一次 view 仍在进行，复用其 Promise 避免 view 被双调；
+      // 首次完成后 pages 已入库，等后的请求通过 resolveCachedCid 命中 store。
+      const viewInfo = (await coalesceViewCall(bvId)) as VideoViewInfo & {
+        cid?: number;
+        aid?: number;
+        pages?: Array<{ cid: number; page: number }>;
+      };
 
       logger.debug('[BILI-API]', 'viewInfo ok', {
         bvid: bvId,
         cid: viewInfo?.cid,
         aid: viewInfo?.aid,
+        videos: (viewInfo as { videos?: number })?.videos,
+        requestPage: page,
       });
 
-      cid = viewInfo?.cid ?? 0;
       aid = viewInfo?.aid;
       descType = viewInfo?.desc_v2?.[0]?.type;
+
+      // 回填 pages/videos 到 bili_videos store：后续切 P 直接拿 cid，省 view 调用。
+      // 强制用请求 bvId 作为 entity key（覆盖 viewInfo.bvid），生产场景两者一致；
+      // 接口异常或 mock 不一致时也能保证入库到正确位置。
+      if (viewInfo && (typeof viewInfo.cid === 'number' || Array.isArray(viewInfo.pages))) {
+        useBilibiliVideosStore
+          .getState()
+          .upsertMany(
+            pickVideosFields({ ...viewInfo, bvid: bvId } as unknown as { bvid: string }, 'view'),
+          );
+      }
+
+      // 取目标 page 的 cid：优先 viewInfo.pages、回退 entity 已入库的 pages、再回退顶层 cid
+      const pickedFromPages =
+        viewInfo?.pages?.find((p) => p.page === page)?.cid ?? resolveCachedCid(bvId, page);
+      if (typeof pickedFromPages === 'number') {
+        cid = pickedFromPages;
+      } else if (page === 1) {
+        cid = viewInfo?.cid ?? 0;
+      } else {
+        cid = 0;
+      }
     } else {
-      logger.debug('[BILI-API]', 'fetchMusicUrl cid hit (skip view)', { bvid: bvId, cid });
+      logger.debug('[BILI-API]', 'fetchMusicUrl cid hit (skip view)', { bvid: bvId, cid, page });
     }
 
     const playInfo = await VideoApi.getVideoPlayurl({
@@ -341,29 +400,42 @@ export async function fetchMusicUrl(
   currentUserMid?: string | number,
   attempt: number = 0,
   options?: FetchMusicUrlOptions,
+  page?: number,
 ): Promise<string> {
-  logger.debug('[BILI-API]', 'fetchMusicUrl enter', { bvid: bvId, attempt });
+  // 防御：page 必须为 >= 1 的整数，否则 fallback 到 1（不抛错以简化调用方）
+  const effectivePage = typeof page === 'number' && Number.isInteger(page) && page >= 1 ? page : 1;
+
+  logger.debug('[BILI-API]', 'fetchMusicUrl enter', { bvid: bvId, attempt, page: effectivePage });
 
   // attempt > 0：bypass 缓存 / inflight；下一档音质需要全新一次 playInfo 请求 + 重新选 audio.id
   const useSharedSlot = attempt === 0;
+  // inflight slot key：bvid + page。同一 bvid 的不同 P 是独立请求，不能复用 promise。
+  // 复用 TrackId 工具构造，避免分散硬编码 `:p` 字面量
+  const inflightKey = buildTrackId(bvId, effectivePage);
 
   if (useSharedSlot) {
-    // 命中已有 inflight 请求：所有并发调用共享同一个 Promise，避免 race
-    const existing = inflightRequests[bvId];
+    // 命中已有 inflight 请求：相同 (bvid, page) 的并发调用共享 Promise，避免 race
+    const existing = inflightRequests[inflightKey];
     if (existing) {
-      logger.debug('[BILI-API]', 'fetchMusicUrl inflight hit', { bvid: bvId });
+      logger.debug('[BILI-API]', 'fetchMusicUrl inflight hit', { bvid: bvId, page: effectivePage });
       return existing;
     }
 
-    // 命中 TTL 内的持久化 URL 缓存：直接 return（重启后同样有效）
-    const urlCacheStore = useMusicUrlCacheStore.getState();
-    const cachedEntry = urlCacheStore.getValid(bvId);
-    if (cachedEntry?.playUrl) {
-      logger.debug('[BILI-API]', 'fetchMusicUrl cache hit', {
-        bvid: bvId,
-        playUrl: cachedEntry.playUrl.slice(0, 80) + '...',
-      });
-      return applyAudioUrlTransformer(cachedEntry.playUrl);
+    // 命中 TTL 内的持久化 URL 缓存：直接 return（重启后同样有效）。
+    // 自 A5 起 cache key 升级为 `bvid:cid`，需先从 bili_videos store 拿到 cid 才能查；
+    // 拿不到（首次播放）时跳过 cache 直接走 attemptFetchMusicUrl 内部 view → upsert 流程。
+    const knownCid = resolveCachedCid(bvId, effectivePage);
+    if (typeof knownCid === 'number') {
+      const cachedEntry = useMusicUrlCacheStore.getState().getValid(bvId, knownCid);
+      if (cachedEntry?.playUrl) {
+        logger.debug('[BILI-API]', 'fetchMusicUrl cache hit', {
+          bvid: bvId,
+          cid: knownCid,
+          page: effectivePage,
+          playUrl: cachedEntry.playUrl.slice(0, 80) + '...',
+        });
+        return applyAudioUrlTransformer(cachedEntry.playUrl);
+      }
     }
   }
 
@@ -389,7 +461,13 @@ export async function fetchMusicUrl(
           await new Promise<void>((r) => setTimeout(r, backoff));
         }
 
-        const result = await attemptFetchMusicUrl(bvId, currentUserMid, attempt, retryCount);
+        const result = await attemptFetchMusicUrl(
+          bvId,
+          currentUserMid,
+          attempt,
+          retryCount,
+          effectivePage,
+        );
         if ('error' in result) {
           lastError = result.error;
           logger.warn('[BILI-API]', 'fetchMusicUrl attempt failed', {
@@ -424,8 +502,9 @@ export async function fetchMusicUrl(
           return '';
         }
 
-        // 写入持久化 URL 缓存：携带 cid 以便重启 / TTL 过期后下次仍可跳过 view
-        useMusicUrlCacheStore.getState().upsert(bvId, { playUrl, cid });
+        // 写入持久化 URL 缓存：key = `${bvId}:${cid}`，重启 / TTL 内可秒命中。
+        // cid 信息由 view 接口入库到 bili_videos store（resolveCachedCid 下次直接拿到）
+        useMusicUrlCacheStore.getState().upsert(bvId, cid, { playUrl });
 
         logger.debug('[BILI-API]', 'fetchMusicUrl resolved', {
           bvid: bvId,
@@ -433,16 +512,17 @@ export async function fetchMusicUrl(
           playUrl: playUrl.slice(0, 80) + '...',
         });
 
-        // 异步发起模拟点击（节流 600s）。aid / type 在 cid 命中跳过 view 时不可知，
-        // 此时以 0 / '1' 兜底（B 站接口允许 aid=0 但点击成功率低，可接受）
+        // 异步发起模拟点击（节流 600s，按 bvid:page 分桶）。
+        // aid / type 在 cid 命中跳过 view 时不可知，以 0 / '1' 兜底。
+        const clickKey = inflightKey;
         setTimeout(() => {
           const now = timeStampNow();
-          if ((musicPlayClickTime[bvId] ?? 0) + CLICK_STAT_THROTTLE > now) return;
+          if ((musicPlayClickTime[clickKey] ?? 0) + CLICK_STAT_THROTTLE > now) return;
           const type = descType ?? '1';
           VideoApi.doClickStat({
             params: {
               w_aid: aid,
-              w_part: 1,
+              w_part: effectivePage,
               w_ftime: now,
               w_stime: now,
               w_type: type,
@@ -451,7 +531,7 @@ export async function fetchMusicUrl(
               aid,
               cid,
               bvid: bvId,
-              part: '1',
+              part: String(effectivePage),
               ftime: now,
               stime: now,
               mid: currentUserMid,
@@ -460,7 +540,7 @@ export async function fetchMusicUrl(
             },
           })
             .then(() => {
-              musicPlayClickTime[bvId] = timeStampNow();
+              musicPlayClickTime[clickKey] = timeStampNow();
             })
             .catch((e) => {
               logger.debug('[BILI-API]', 'doClickStat failed', e);
@@ -483,22 +563,27 @@ export async function fetchMusicUrl(
       return '';
     } finally {
       // attempt > 0 没有写入 inflight slot，跳过 delete 避免误删 attempt=0 的并发请求
-      if (useSharedSlot) delete inflightRequests[bvId];
+      if (useSharedSlot) delete inflightRequests[inflightKey];
     }
   })();
 
-  if (useSharedSlot) inflightRequests[bvId] = promise;
+  if (useSharedSlot) inflightRequests[inflightKey] = promise;
   return promise;
 }
 
 /**
- * 清除指定 bvid 的播放 URL 缓存（用于风控重试场景）。
+ * 清除指定 bvid 的播放 URL 缓存与 inflight（用于风控重试场景）。
  * 不传 bvid 则清空全部缓存与 inflight。
+ *
+ * 多 P 投稿：清空该 bvid 下所有 P 的缓存与 inflight slot（前缀匹配 `${bvid}:p`）。
  */
 export function invalidateMusicUrlCache(bvId?: string): void {
   useMusicUrlCacheStore.getState().invalidate(bvId);
   if (bvId) {
-    delete inflightRequests[bvId];
+    // inflightKey 形如 bvid 或 bvid:p<n>（见 buildTrackId）。前缀匹配清掉所有 P 的 slot。
+    for (const key of Object.keys(inflightRequests)) {
+      if (key === bvId || key.startsWith(`${bvId}:`)) delete inflightRequests[key];
+    }
     return;
   }
   Object.keys(inflightRequests).forEach((k) => delete inflightRequests[k]);

--- a/packages/shared/src/utils/track-id.test.ts
+++ b/packages/shared/src/utils/track-id.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { parseTrackId, buildTrackId, trackIdToBvid, isExplicitPageTrackId } from './track-id';
+
+describe('parseTrackId', () => {
+  it('解析纯 bvid', () => {
+    expect(parseTrackId('BV1aB4y1k7Yx')).toEqual({ bvid: 'BV1aB4y1k7Yx' });
+  });
+
+  it('解析带 :p<n> 的 TrackId（n >= 2）', () => {
+    expect(parseTrackId('BV1aB4y1k7Yx:p2')).toEqual({ bvid: 'BV1aB4y1k7Yx', page: 2 });
+    expect(parseTrackId('BV1aB4y1k7Yx:p99')).toEqual({ bvid: 'BV1aB4y1k7Yx', page: 99 });
+  });
+
+  it('拒绝 :p1（page=1 应表达为纯 bvid）', () => {
+    expect(parseTrackId('BV1aB4y1k7Yx:p1')).toBeNull();
+  });
+
+  it('拒绝 :p0 / :p- 等非法 page', () => {
+    expect(parseTrackId('BV1aB4y1k7Yx:p0')).toBeNull();
+    expect(parseTrackId('BV1aB4y1k7Yx:p-1')).toBeNull();
+  });
+
+  it('拒绝非 BV 前缀', () => {
+    expect(parseTrackId('av12345')).toBeNull();
+    expect(parseTrackId('12345')).toBeNull();
+    expect(parseTrackId('bv1aB4y1k7Yx')).toBeNull(); // 小写
+  });
+
+  it('拒绝空串 / 非字符串', () => {
+    expect(parseTrackId('')).toBeNull();
+    // @ts-expect-error 测试非法输入
+    expect(parseTrackId(undefined)).toBeNull();
+    // @ts-expect-error 测试非法输入
+    expect(parseTrackId(null)).toBeNull();
+  });
+
+  it('拒绝带额外尾随字符', () => {
+    expect(parseTrackId('BV1aB4y1k7Yx:p2:extra')).toBeNull();
+    expect(parseTrackId('BV1aB4y1k7Yx:p2 ')).toBeNull();
+  });
+});
+
+describe('buildTrackId', () => {
+  it('page 缺省 / undefined / null / 1 → 返回纯 bvid', () => {
+    expect(buildTrackId('BV1aB4y1k7Yx')).toBe('BV1aB4y1k7Yx');
+    expect(buildTrackId('BV1aB4y1k7Yx', undefined)).toBe('BV1aB4y1k7Yx');
+    expect(buildTrackId('BV1aB4y1k7Yx', null)).toBe('BV1aB4y1k7Yx');
+    expect(buildTrackId('BV1aB4y1k7Yx', 1)).toBe('BV1aB4y1k7Yx');
+  });
+
+  it('page >= 2 → 拼 :p<n>', () => {
+    expect(buildTrackId('BV1aB4y1k7Yx', 2)).toBe('BV1aB4y1k7Yx:p2');
+    expect(buildTrackId('BV1aB4y1k7Yx', 99)).toBe('BV1aB4y1k7Yx:p99');
+  });
+
+  it('page 非法（0 / 负 / 非整数）→ 回退纯 bvid', () => {
+    expect(buildTrackId('BV1aB4y1k7Yx', 0)).toBe('BV1aB4y1k7Yx');
+    expect(buildTrackId('BV1aB4y1k7Yx', -1)).toBe('BV1aB4y1k7Yx');
+    expect(buildTrackId('BV1aB4y1k7Yx', 1.5)).toBe('BV1aB4y1k7Yx');
+    expect(buildTrackId('BV1aB4y1k7Yx', NaN)).toBe('BV1aB4y1k7Yx');
+  });
+});
+
+describe('trackIdToBvid', () => {
+  it('合法 TrackId → 返回 bvid', () => {
+    expect(trackIdToBvid('BV1aB4y1k7Yx')).toBe('BV1aB4y1k7Yx');
+    expect(trackIdToBvid('BV1aB4y1k7Yx:p3')).toBe('BV1aB4y1k7Yx');
+  });
+
+  it('非合法字符串 → 取 ":" 前部分作为兜底', () => {
+    // 历史存量场景：截到冒号前；无冒号则原值返回
+    expect(trackIdToBvid('garbage')).toBe('garbage');
+    expect(trackIdToBvid('weird:tag:rest')).toBe('weird');
+  });
+});
+
+describe('isExplicitPageTrackId', () => {
+  it('显式 :p<n> → true', () => {
+    expect(isExplicitPageTrackId('BV1aB4y1k7Yx:p2')).toBe(true);
+  });
+
+  it('纯 bvid → false', () => {
+    expect(isExplicitPageTrackId('BV1aB4y1k7Yx')).toBe(false);
+  });
+
+  it('非法 TrackId → false', () => {
+    expect(isExplicitPageTrackId('garbage')).toBe(false);
+    expect(isExplicitPageTrackId('BV1aB4y1k7Yx:p1')).toBe(false);
+  });
+});
+
+describe('round-trip', () => {
+  it('parse → build 等价（page 缺省）', () => {
+    const parsed = parseTrackId('BV1aB4y1k7Yx');
+    expect(parsed).not.toBeNull();
+    expect(buildTrackId(parsed!.bvid, parsed!.page)).toBe('BV1aB4y1k7Yx');
+  });
+
+  it('parse → build 等价（带 page）', () => {
+    const parsed = parseTrackId('BV1aB4y1k7Yx:p7');
+    expect(parsed).not.toBeNull();
+    expect(buildTrackId(parsed!.bvid, parsed!.page)).toBe('BV1aB4y1k7Yx:p7');
+  });
+});

--- a/packages/shared/src/utils/track-id.ts
+++ b/packages/shared/src/utils/track-id.ts
@@ -1,0 +1,90 @@
+/**
+ * TrackId：统一表达"播放/收藏的最小单位"
+ *
+ * 形态：
+ * - 纯 bvid（如 'BV1aB4y1k7Yx'）→ 表示"整个投稿"，播放时按默认 P / 第一 P 取流
+ * - bvid:p<n>（如 'BV1aB4y1k7Yx:p3'）→ 表示"显式锁定该 P"，n >= 2
+ *
+ * 不变量：
+ * - page === 1 永远表达为纯 bvid，不允许出现 ':p1' 后缀
+ * - page 必须为 >= 2 的正整数
+ * - bvid 形态约束：BV 前缀 + 字母数字
+ *
+ * 解析失败的字符串视为"非合法 TrackId"，parseTrackId 返回 null，
+ * 调用方应用 trackIdToBvid 做兜底转换以兼容历史存量数据。
+ */
+
+const TRACK_ID_PATTERN = /^(BV[A-Za-z0-9]+)(?::p(\d+))?$/;
+
+export interface ParsedTrackId {
+  bvid: string;
+  /** 显式指定的分 P 序号；缺失表示"按默认/首 P" */
+  page?: number;
+}
+
+/**
+ * 解析 TrackId。
+ *
+ * 严格校验：
+ * - 不匹配 BV 正则 → null
+ * - :p0 / :p1 / :p- 等非法 page → null（注：:p1 是冗余表达，禁止）
+ *
+ * @returns 解析成功 → { bvid, page? }；失败 → null
+ */
+export function parseTrackId(id: string): ParsedTrackId | null {
+  if (typeof id !== 'string' || id.length === 0) return null;
+  const m = TRACK_ID_PATTERN.exec(id);
+  if (!m) return null;
+  const bvid = m[1]!;
+  const pageStr = m[2];
+  if (pageStr === undefined) return { bvid };
+  const page = Number(pageStr);
+  if (!Number.isInteger(page) || page < 2) return null;
+  return { bvid, page };
+}
+
+/**
+ * 组装 TrackId。
+ *
+ * 规则：
+ * - page 缺省、undefined、null、1 → 返回纯 bvid
+ * - page >= 2 → 返回 `${bvid}:p${page}`
+ * - page < 1 或非整数 → 视为非法，回退到纯 bvid（不抛错以保持调用侧简单）
+ */
+export function buildTrackId(bvid: string, page?: number | null): string {
+  if (page == null) return bvid;
+  if (!Number.isInteger(page) || page <= 1) return bvid;
+  return `${bvid}:p${page}`;
+}
+
+/**
+ * 提取 bvid。解析失败时返回原值（兼容历史存量数据：可能存在非 BV 开头的脏数据，
+ * 例如旧版 numeric aid 字符串）。
+ */
+export function trackIdToBvid(id: string): string {
+  const parsed = parseTrackId(id);
+  if (parsed) return parsed.bvid;
+  // fallback：截到第一个 ':' 之前
+  const colonIdx = id.indexOf(':');
+  return colonIdx >= 0 ? id.slice(0, colonIdx) : id;
+}
+
+/**
+ * 是否显式指定了 P（带 :p<n> 后缀）。
+ *
+ * 用于 UI 决策（如显式 TrackId 的 onend 永远走 next() 而非分 P 连播）。
+ */
+export function isExplicitPageTrackId(id: string): boolean {
+  const parsed = parseTrackId(id);
+  return parsed !== null && parsed.page !== undefined;
+}
+
+/**
+ * 轻量后缀检测：字符串是否含 ':p' 标记（不做完整 BV 校验）。
+ *
+ * 用于 hydrate / persist 路径上 O(N) 扫描旧脏数据时的快速预判，
+ * 避免对每条 entry 都调用完整的 parseTrackId 正则。
+ */
+export function hasPageSuffix(id: string): boolean {
+  return typeof id === 'string' && id.includes(':p');
+}

--- a/packages/web/public/manifest.json
+++ b/packages/web/public/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "说说播放器",
+  "name": "说说播放器-水晶蟹定制版",
   "version": "1.9.1",
-  "description": "基于 Bilibili 的第三方音乐播放器 - 水晶蟹定制版",
+  "description": "说说播放器是一款基于Bilibili的第三方音乐播放器，可以将说宝B站视频投稿变成你的歌单，沉浸式享受音乐盛宴",
   "icons": {
     "16": "logo16.png",
     "48": "logo48.png",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,7 @@ import { BilibiliLoginRequired } from '@/components/bilibili-login-required';
 import { FavEditDialog } from '@/components/dialogs/fav-edit-dialog';
 import { AddSongDialog } from '@/components/dialogs/add-song-dialog';
 import { AddToFavDialog } from '@/components/dialogs/add-to-fav-dialog';
+import { PagesPickerDialog } from '@/components/dialogs/pages-picker-dialog';
 import { ConfirmDialog } from '@/components/dialogs/confirm-dialog';
 import { RiskControlDialog } from '@/components/dialogs/risk-control-dialog';
 import { useUIShell } from '@/stores/ui-shell';
@@ -71,6 +72,7 @@ function RootLayout() {
           <FavEditDialog />
           <AddSongDialog />
           <AddToFavDialog />
+          <PagesPickerDialog />
           <ConfirmDialog />
           <RiskControlDialog />
         </>

--- a/packages/web/src/components/dialogs/add-to-fav-dialog.test.tsx
+++ b/packages/web/src/components/dialogs/add-to-fav-dialog.test.tsx
@@ -3,10 +3,12 @@ import {
   useBilibiliUserVideosStore,
   useBilibiliVideosStore,
   useFavListStore,
+  usePlayingListStore,
   useUIStore,
   FavListType,
 } from '@shuoshuo-player/shared';
 import { useUIShell } from '@/stores/ui-shell';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
 import { AddToFavDialog } from './add-to-fav-dialog';
 
 function makeFav(id: string, name: string, type: FavListType, bv_ids: string[] = []) {
@@ -140,6 +142,199 @@ describe('AddToFavDialog', () => {
     act(() => useUIShell.getState().openAddToFav('BV1'));
 
     expect(screen.getByRole('button', { name: '确认添加' })).toBeDisabled();
+  });
+
+  it('单 P 投稿：不显示"整投稿/指定 P" RadioGroup（D2）', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1'],
+      entities: { BV1: { bvid: 'BV1', title: '单 P', videos: 1 } as never },
+    });
+    useFavListStore.setState({
+      list: [makeFav('c1', 'My Songs', FavListType.CUSTOM)],
+    });
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1'));
+    expect(screen.queryByText('将什么加入歌单？')).not.toBeInTheDocument();
+  });
+
+  it('多 P 投稿 + 当前播放 P>=2：显示 RadioGroup，默认"整投稿"', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: '多 P',
+          videos: 3,
+          pages: [
+            { cid: 1, page: 1, part: 'A', duration: 0 },
+            { cid: 2, page: 2, part: 'B', duration: 0 },
+            { cid: 3, page: 3, part: 'C', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [makeFav('c1', 'My Songs', FavListType.CUSTOM)],
+    });
+    // 当前播放 BV1Multi 的 P2
+    usePlayingListStore.setState({
+      favId: '',
+      trackIds: ['BV1Multi'],
+      current: 'BV1Multi',
+      playNext: false,
+    });
+    usePlayerRuntimeStore.setState({ playingPage: 2, progress: 0, duration: 0 });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi'));
+
+    expect(screen.getByText('将什么加入歌单？')).toBeInTheDocument();
+    // 默认选中"整投稿"（因为入参不含 :p<n>）
+    const videoMode = screen.getByRole('radio', { name: /整个投稿/ }) as HTMLButtonElement;
+    expect(videoMode.getAttribute('data-state')).toBe('checked');
+    // "仅 P2 · B" 选项存在
+    expect(screen.getByText(/仅 P2/)).toBeInTheDocument();
+    expect(screen.getByText(/· B/)).toBeInTheDocument();
+  });
+
+  it('入参含 :p<n>：默认选中"指定 P"模式，提交写入 :p<n> trackId', async () => {
+    const addFavVideo = vi.fn();
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: 'M',
+          videos: 3,
+          pages: [
+            { cid: 1, page: 1, part: 'A', duration: 0 },
+            { cid: 2, page: 2, part: 'B', duration: 0 },
+            { cid: 3, page: 3, part: 'C', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [makeFav('c1', 'My Songs', FavListType.CUSTOM)],
+      addFavVideo,
+    });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi:p3'));
+
+    // 默认指定 P 模式
+    const pageMode = screen.getByRole('radio', { name: /仅 P3/ }) as HTMLButtonElement;
+    expect(pageMode.getAttribute('data-state')).toBe('checked');
+
+    fireEvent.click(screen.getByText('My Songs').closest('button')!);
+    fireEvent.click(screen.getByRole('button', { name: '确认添加' }));
+
+    expect(addFavVideo).toHaveBeenCalledWith('c1', 'BV1Multi:p3');
+  });
+
+  it('多 P 投稿入参纯 bvid 但当前播放 P=1：不显示 RadioGroup（无指定 P 可选）', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: 'M',
+          videos: 2,
+          pages: [
+            { cid: 1, page: 1, part: 'A', duration: 0 },
+            { cid: 2, page: 2, part: 'B', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [makeFav('c1', 'My Songs', FavListType.CUSTOM)],
+    });
+    // 当前不在播放该投稿 → targetPage fallback 1，不显示
+    usePlayingListStore.setState({
+      favId: '',
+      trackIds: [],
+      current: '',
+      playNext: false,
+    });
+    usePlayerRuntimeStore.setState({ playingPage: 1, progress: 0, duration: 0 });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi'));
+
+    expect(screen.queryByText('将什么加入歌单？')).not.toBeInTheDocument();
+  });
+
+  it('指定 P 模式 + 仅 UPLOADER/BILI_FAV 歌单存在 → 显示"暂无可添加的自定义歌单"（F5）', () => {
+    // §5.4 设计：UPLOADER/BILI_FAV 不接受 :p<n>，dialog 列表仅渲染 CUSTOM；
+    // 当无 CUSTOM 歌单时，多 P 上下文也走"空状态"分支
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: 'M',
+          videos: 2,
+          pages: [
+            { cid: 1, page: 1, part: '', duration: 0 },
+            { cid: 2, page: 2, part: '', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [
+        makeFav('u1', 'UP 主歌单', FavListType.UPLOADER),
+        makeFav('b1', 'B 站收藏夹', FavListType.BILI_FAV),
+      ],
+    });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi:p2'));
+
+    // dialog 显示空状态文案（UPLOADER / BILI_FAV 不渲染为可选项）
+    expect(screen.getByText(/暂无可添加的自定义歌单/)).toBeInTheDocument();
+    expect(screen.queryByText('UP 主歌单')).not.toBeInTheDocument();
+    expect(screen.queryByText('B 站收藏夹')).not.toBeInTheDocument();
+  });
+
+  it('多 P 投稿 + 切换到"仅 P{n}"模式后提交 → 写入 bvid:p<n>', async () => {
+    const addFavVideo = vi.fn();
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: 'M',
+          videos: 2,
+          pages: [
+            { cid: 1, page: 1, part: '', duration: 0 },
+            { cid: 2, page: 2, part: '', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [makeFav('c1', 'My Songs', FavListType.CUSTOM)],
+      addFavVideo,
+    });
+    usePlayingListStore.setState({
+      favId: '',
+      trackIds: ['BV1Multi'],
+      current: 'BV1Multi',
+      playNext: false,
+    });
+    usePlayerRuntimeStore.setState({ playingPage: 2, progress: 0, duration: 0 });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi'));
+
+    // 切换到 "仅 P2"
+    fireEvent.click(screen.getByRole('radio', { name: /仅 P2/ }));
+    fireEvent.click(screen.getByText('My Songs').closest('button')!);
+    fireEvent.click(screen.getByRole('button', { name: '确认添加' }));
+
+    expect(addFavVideo).toHaveBeenCalledWith('c1', 'BV1Multi:p2');
   });
 
   it('批量模式：标题/描述切换 + 提交调用 addFavVideoByBvids', async () => {

--- a/packages/web/src/components/dialogs/add-to-fav-dialog.test.tsx
+++ b/packages/web/src/components/dialogs/add-to-fav-dialog.test.tsx
@@ -337,6 +337,89 @@ describe('AddToFavDialog', () => {
     expect(addFavVideo).toHaveBeenCalledWith('c1', 'BV1Multi:p2');
   });
 
+  it('单条模式：目标歌单已含 writeTrackId → 禁用 + 显示"已包含"', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: 'M',
+          videos: 2,
+          pages: [
+            { cid: 1, page: 1, part: '', duration: 0 },
+            { cid: 2, page: 2, part: '', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [
+        makeFav('c1', 'Already Has', FavListType.CUSTOM, ['BV1Multi:p2']),
+        makeFav('c2', 'Empty', FavListType.CUSTOM, []),
+      ],
+    });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi:p2'));
+
+    const alreadyBtn = screen.getByText('Already Has').closest('button') as HTMLButtonElement;
+    const emptyBtn = screen.getByText('Empty').closest('button') as HTMLButtonElement;
+    expect(alreadyBtn).toBeDisabled();
+    expect(emptyBtn).not.toBeDisabled();
+    expect(screen.getByText('已包含')).toBeInTheDocument();
+  });
+
+  it('单条多 P 模式切换：切到"整投稿"后禁用态按纯 bvid 重算', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Multi'],
+      entities: {
+        BV1Multi: {
+          bvid: 'BV1Multi',
+          title: 'M',
+          videos: 2,
+          pages: [
+            { cid: 1, page: 1, part: '', duration: 0 },
+            { cid: 2, page: 2, part: '', duration: 0 },
+          ],
+        } as never,
+      },
+    });
+    useFavListStore.setState({
+      list: [
+        // 歌单已含 :p2 但没有纯 bvid
+        makeFav('c1', 'Has Page Only', FavListType.CUSTOM, ['BV1Multi:p2']),
+      ],
+    });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFav('BV1Multi:p2'));
+    // 默认"仅 P2"模式 → c1 已包含禁用
+    expect(screen.getByText('Has Page Only').closest('button')).toBeDisabled();
+
+    // 切到"整投稿"模式 → writeTrackId 变为纯 bvid，c1 不含 → 启用
+    fireEvent.click(screen.getByRole('radio', { name: /整个投稿/ }));
+    expect(screen.getByText('Has Page Only').closest('button')).not.toBeDisabled();
+  });
+
+  it('批量模式：歌单完全包含所有待添加项 → 禁用 + 显示"已全部包含"', () => {
+    useFavListStore.setState({
+      list: [
+        makeFav('c1', 'Full Coverage', FavListType.CUSTOM, ['BVa', 'BVb', 'BVc']),
+        makeFav('c2', 'Partial', FavListType.CUSTOM, ['BVa']),
+        makeFav('c3', 'None', FavListType.CUSTOM, []),
+      ],
+    });
+
+    render(<AddToFavDialog />);
+    act(() => useUIShell.getState().openAddToFavBatch(['BVa', 'BVb']));
+
+    expect(screen.getByText('Full Coverage').closest('button')).toBeDisabled();
+    expect(screen.getByText('已全部包含')).toBeInTheDocument();
+    // 部分包含仍允许（store 内部去重）
+    expect(screen.getByText('Partial').closest('button')).not.toBeDisabled();
+    expect(screen.getByText('None').closest('button')).not.toBeDisabled();
+  });
+
   it('批量模式：标题/描述切换 + 提交调用 addFavVideoByBvids', async () => {
     const addFavVideoByBvids = vi.fn(async () => ({ success: 3, failed: 0 }));
     useFavListStore.setState({

--- a/packages/web/src/components/dialogs/add-to-fav-dialog.tsx
+++ b/packages/web/src/components/dialogs/add-to-fav-dialog.tsx
@@ -4,12 +4,18 @@ import {
   useFavListStore,
   useBilibiliVideosStore,
   useBilibiliUserVideosStore,
+  usePlayingListStore,
   useUIStore,
+  parseTrackId,
+  buildTrackId,
+  trackIdToBvid,
   FavListType,
   NoticeType,
 } from '@shuoshuo-player/shared';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Dialog,
@@ -20,6 +26,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { useUIShell } from '@/stores/ui-shell';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
 
 /**
  * 添加到歌单弹窗（支持单条与批量两种模式）。
@@ -42,18 +49,31 @@ export function AddToFavDialog() {
   const videoEntities = useBilibiliVideosStore((s) => s.entities);
   const getVideoByBvid = useBilibiliUserVideosStore((s) => s.getVideoByBvid);
   const sendNotice = useUIStore((s) => s.sendNotice);
+  const currentTrackId = usePlayingListStore((s) => s.current);
+  const playingPage = usePlayerRuntimeStore((s) => s.playingPage);
 
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [fetching, setFetching] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  /** 单条 + 多 P 模式下的添加模式：整投稿 | 指定 P */
+  const [partMode, setPartMode] = useState<'video' | 'page'>('video');
 
   const isBatch = bvids.length > 1;
-  const singleBvid = !isBatch ? bvids[0] : undefined;
+  // 单条入参可能是 trackId（含 :p<n>），解析出 bvid 与 explicitPage
+  const singleTrackId = !isBatch ? bvids[0] : undefined;
+  const singleParsed = useMemo(
+    () => (singleTrackId ? parseTrackId(singleTrackId) : null),
+    [singleTrackId],
+  );
+  const singleBvid =
+    singleParsed?.bvid ?? (singleTrackId ? trackIdToBvid(singleTrackId) : undefined);
+  const explicitPage = singleParsed?.page;
 
   useEffect(() => {
     if (!open) {
       setSelected(new Set());
       setSubmitting(false);
+      setPartMode('video');
       return;
     }
     // 单条 + fromSearch 模式下确保视频信息已在 store（用于显示标题）
@@ -61,13 +81,26 @@ export function AddToFavDialog() {
       setFetching(true);
       getVideoByBvid(singleBvid).finally(() => setFetching(false));
     }
-  }, [open, singleBvid, fromSearch, videoEntities, getVideoByBvid]);
+    // 入参含 :p<n> → 默认选"指定 P"模式；否则默认整投稿
+    setPartMode(explicitPage !== undefined ? 'page' : 'video');
+  }, [open, singleBvid, fromSearch, videoEntities, getVideoByBvid, explicitPage]);
 
   const customLists = useMemo(
     () => favList.filter((f) => f.type === FavListType.CUSTOM),
     [favList],
   );
   const singleVideo = singleBvid ? videoEntities[singleBvid] : undefined;
+
+  // 决定"指定 P"模式下使用哪个 P：
+  // - 入参显式 :p<n> → 用 n
+  // - 否则用当前正在播放的 P（仅当 video 是当前播放投稿；fallback P1）
+  const isCurrentlyPlaying =
+    singleBvid !== undefined && trackIdToBvid(currentTrackId) === singleBvid;
+  const targetPage = explicitPage ?? (isCurrentlyPlaying ? playingPage : 1);
+  const targetPagePart = singleVideo?.pages?.[targetPage - 1]?.part;
+  const isMultiPart = (singleVideo?.videos ?? 1) > 1;
+  /** 是否显示"整投稿 / 指定 P"二选项 */
+  const showPartModeRadio = !isBatch && isMultiPart && targetPage >= 2;
 
   const toggle = (favId: string) => {
     if (favId === excludeId) return;
@@ -85,8 +118,14 @@ export function AddToFavDialog() {
       return;
     }
     if (!isBatch) {
-      // 单条：同步逐歌单写入
-      selected.forEach((favId) => addFavVideo(favId, bvids[0]));
+      // 单条：按 partMode 决定写入的 TrackId
+      // - 'video' / 单 P 投稿：纯 bvid
+      // - 'page'  + 多 P 投稿：buildTrackId(bvid, targetPage)
+      const writeTrackId =
+        showPartModeRadio && partMode === 'page' && singleBvid
+          ? buildTrackId(singleBvid, targetPage)
+          : (singleBvid ?? bvids[0]);
+      selected.forEach((favId) => addFavVideo(favId, writeTrackId));
       sendNotice({
         type: NoticeType.SUCCESS,
         message: `已添加到 ${selected.size} 个歌单`,
@@ -126,6 +165,38 @@ export function AddToFavDialog() {
         </DialogHeader>
 
         {!isBatch && fetching && <p className="text-sm text-muted-foreground">加载视频信息…</p>}
+
+        {showPartModeRadio && (
+          <div className="rounded-md border border-border bg-muted/30 p-3">
+            <Label className="text-xs text-muted-foreground">将什么加入歌单？</Label>
+            <RadioGroup
+              value={partMode}
+              onValueChange={(v) => setPartMode(v as 'video' | 'page')}
+              className="mt-2 flex flex-col gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="video" id="part-mode-video" />
+                <Label htmlFor="part-mode-video" className="cursor-pointer text-sm font-normal">
+                  整个投稿
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    （播放时按默认 P / P1）
+                  </span>
+                </Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="page" id="part-mode-page" />
+                <Label htmlFor="part-mode-page" className="cursor-pointer text-sm font-normal">
+                  仅 P{targetPage}
+                  {targetPagePart && (
+                    <span className="ml-1 truncate text-xs text-muted-foreground">
+                      · {targetPagePart}
+                    </span>
+                  )}
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+        )}
 
         {customLists.length === 0 ? (
           <p className="py-6 text-center text-sm text-muted-foreground">

--- a/packages/web/src/components/dialogs/add-to-fav-dialog.tsx
+++ b/packages/web/src/components/dialogs/add-to-fav-dialog.tsx
@@ -102,6 +102,17 @@ export function AddToFavDialog() {
   /** 是否显示"整投稿 / 指定 P"二选项 */
   const showPartModeRadio = !isBatch && isMultiPart && targetPage >= 2;
 
+  /**
+   * 计算单条模式下实际要写入的 TrackId（与 handleConfirm 内逻辑同步），
+   * 用于"目标歌单已包含该 TrackId 时禁用"的检测。
+   */
+  const writeTrackIdForSingle = useMemo(() => {
+    if (isBatch || !singleBvid) return undefined;
+    return showPartModeRadio && partMode === 'page'
+      ? buildTrackId(singleBvid, targetPage)
+      : singleBvid;
+  }, [isBatch, singleBvid, showPartModeRadio, partMode, targetPage]);
+
   const toggle = (favId: string) => {
     if (favId === excludeId) return;
     setSelected((prev) => {
@@ -174,21 +185,27 @@ export function AddToFavDialog() {
               onValueChange={(v) => setPartMode(v as 'video' | 'page')}
               className="mt-2 flex flex-col gap-2"
             >
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="video" id="part-mode-video" />
-                <Label htmlFor="part-mode-video" className="cursor-pointer text-sm font-normal">
-                  整个投稿
-                  <span className="ml-1 text-xs text-muted-foreground">
+              <div className="flex min-w-0 items-center gap-2">
+                <RadioGroupItem value="video" id="part-mode-video" className="shrink-0" />
+                <Label
+                  htmlFor="part-mode-video"
+                  className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-sm font-normal"
+                >
+                  <span className="shrink-0">整个投稿</span>
+                  <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
                     （播放时按默认 P / P1）
                   </span>
                 </Label>
               </div>
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="page" id="part-mode-page" />
-                <Label htmlFor="part-mode-page" className="cursor-pointer text-sm font-normal">
-                  仅 P{targetPage}
+              <div className="flex min-w-0 items-center gap-2">
+                <RadioGroupItem value="page" id="part-mode-page" className="shrink-0" />
+                <Label
+                  htmlFor="part-mode-page"
+                  className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-sm font-normal"
+                >
+                  <span className="shrink-0">仅 P{targetPage}</span>
                   {targetPagePart && (
-                    <span className="ml-1 truncate text-xs text-muted-foreground">
+                    <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
                       · {targetPagePart}
                     </span>
                   )}
@@ -207,17 +224,32 @@ export function AddToFavDialog() {
             <div className="flex flex-col gap-1">
               {customLists.map((fav) => {
                 const isExcluded = !isBatch && fav.id === excludeId;
+                // 动态检测：目标歌单是否已包含待添加的 TrackId
+                // - 单条模式：歌单的 bv_ids 是否包含 writeTrackIdForSingle
+                // - 批量模式：歌单是否已完全包含所有待添加项（部分包含仍允许，store 内部去重）
+                const containsAll = isBatch
+                  ? bvids.length > 0 && bvids.every((id) => fav.bv_ids.includes(id))
+                  : writeTrackIdForSingle !== undefined &&
+                    fav.bv_ids.includes(writeTrackIdForSingle);
+                const isDisabled = isExcluded || containsAll;
                 const isSelected = selected.has(fav.id);
+                const disabledLabel = isExcluded
+                  ? '已包含'
+                  : containsAll
+                    ? isBatch
+                      ? '已全部包含'
+                      : '已包含'
+                    : null;
                 return (
                   <button
                     key={fav.id}
                     type="button"
-                    disabled={isExcluded || submitting}
+                    disabled={isDisabled || submitting}
                     onClick={() => toggle(fav.id)}
                     className={cn(
                       'flex items-center gap-2 rounded-md border px-3 py-2 text-left transition-colors',
                       isSelected ? 'border-primary bg-primary/10' : 'border-input',
-                      (isExcluded || submitting) && 'cursor-not-allowed opacity-50',
+                      (isDisabled || submitting) && 'cursor-not-allowed opacity-50',
                     )}
                   >
                     {iconForType(fav.type)}
@@ -227,7 +259,9 @@ export function AddToFavDialog() {
                         {fav.bv_ids.length} 首
                       </p>
                     </div>
-                    {isExcluded && <span className="text-xs text-muted-foreground">已包含</span>}
+                    {disabledLabel && (
+                      <span className="text-xs text-muted-foreground">{disabledLabel}</span>
+                    )}
                   </button>
                 );
               })}

--- a/packages/web/src/components/dialogs/pages-picker-dialog.test.tsx
+++ b/packages/web/src/components/dialogs/pages-picker-dialog.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { type BilibiliVideo } from '@shuoshuo-player/shared';
+import { useUIShell } from '@/stores/ui-shell';
+import { PagesPickerDialog } from './pages-picker-dialog';
+
+const MULTI: BilibiliVideo = {
+  aid: 1,
+  bvid: 'BV1Multi00001',
+  created: 0,
+  length: '',
+  pic: '',
+  is_union_video: false,
+  title: '多 P 合集',
+  sub_title: '',
+  play: 0,
+  comment: 0,
+  author: '',
+  description: '',
+  videos: 3,
+  pages: [
+    { cid: 100, page: 1, part: 'Intro', duration: 60 },
+    { cid: 101, page: 2, part: 'Verse', duration: 90 },
+    { cid: 102, page: 3, part: 'Outro', duration: 30 },
+  ],
+};
+
+function reset() {
+  useUIShell.setState({
+    pagesPickerOpen: false,
+    pagesPickerVideo: null,
+    addToFavOpen: false,
+    addToFavBvids: [],
+    addToFavExcludeId: null,
+    addToFavFromSearch: false,
+  });
+}
+
+describe('PagesPickerDialog', () => {
+  beforeEach(reset);
+
+  it('store flag 关闭时不渲染', () => {
+    render(<PagesPickerDialog />);
+    expect(screen.queryByText('选择分 P 添加到歌单')).not.toBeInTheDocument();
+  });
+
+  it('打开后显示标题 + 投稿标题 + 共 N P', () => {
+    render(<PagesPickerDialog />);
+    act(() => useUIShell.getState().openPagesPicker(MULTI));
+    expect(screen.getByText('选择分 P 添加到歌单')).toBeInTheDocument();
+    expect(screen.getByText('多 P 合集')).toBeInTheDocument();
+    expect(screen.getByText(/共 3 P/)).toBeInTheDocument();
+  });
+
+  it('单选切勾：点行 → 选中 + "已选 N" 计数同步', () => {
+    render(<PagesPickerDialog />);
+    act(() => useUIShell.getState().openPagesPicker(MULTI));
+    fireEvent.click(screen.getByRole('option', { name: /选择 P2/ }));
+    expect(screen.getByText(/已选 1/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('option', { name: /选择 P3/ }));
+    expect(screen.getByText(/已选 2/)).toBeInTheDocument();
+  });
+
+  it('全选 / 取消全选', () => {
+    render(<PagesPickerDialog />);
+    act(() => useUIShell.getState().openPagesPicker(MULTI));
+    fireEvent.click(screen.getByRole('checkbox', { name: '全选' }));
+    expect(screen.getByText(/已选 3/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: '取消全选' }));
+    expect(screen.getByText(/已选 0/)).toBeInTheDocument();
+  });
+
+  it('提交：openAddToFavBatch 收到 sorted trackIds（P1 转纯 bvid）', async () => {
+    const openAddToFavBatch = vi.fn();
+    useUIShell.setState({ openAddToFavBatch });
+    render(<PagesPickerDialog />);
+    act(() => useUIShell.getState().openPagesPicker(MULTI));
+
+    fireEvent.click(screen.getByRole('option', { name: /选择 P3/ }));
+    fireEvent.click(screen.getByRole('option', { name: /选择 P1/ }));
+    fireEvent.click(screen.getByRole('button', { name: /添加 \(2\)/ }));
+
+    // 按 page 升序排序：P1 → 纯 bvid，P3 → bvid:p3
+    expect(openAddToFavBatch).toHaveBeenCalledWith([MULTI.bvid, `${MULTI.bvid}:p3`]);
+    await waitFor(() => expect(useUIShell.getState().pagesPickerOpen).toBe(false));
+  });
+
+  it('选中为空时"添加"按钮 disabled', () => {
+    render(<PagesPickerDialog />);
+    act(() => useUIShell.getState().openPagesPicker(MULTI));
+    const btn = screen.getByRole('button', { name: /添加 \(0\)/ }) as HTMLButtonElement;
+    expect(btn).toBeDisabled();
+  });
+
+  it('点击取消关闭 dialog', async () => {
+    render(<PagesPickerDialog />);
+    act(() => useUIShell.getState().openPagesPicker(MULTI));
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+    await waitFor(() => expect(useUIShell.getState().pagesPickerOpen).toBe(false));
+  });
+});

--- a/packages/web/src/components/dialogs/pages-picker-dialog.tsx
+++ b/packages/web/src/components/dialogs/pages-picker-dialog.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useState } from 'react';
+import { buildTrackId, type BilibiliVideo } from '@shuoshuo-player/shared';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { useUIShell } from '@/stores/ui-shell';
+import { PartList } from '@/components/player/part-list';
+
+/**
+ * 批量分 P 选择对话框（VideoItem 三点菜单触发）。
+ *
+ * Dialog body 复用 PartList selectable + hidePinColumn + hideActiveHighlight：
+ * 仅用于"选哪几 P 加入歌单"，不涉及播放上下文或默认 P 偏好。
+ *
+ * 提交时调 openAddToFavBatch(trackIds, { fromSearch })，trackIds 由
+ * buildTrackId(bvid, page) 拼装（P1 自动转纯 bvid，与"整投稿"语义对齐）。
+ */
+export function PagesPickerDialog() {
+  const open = useUIShell((s) => s.pagesPickerOpen);
+  const close = useUIShell((s) => s.closePagesPicker);
+  const video = useUIShell((s) => s.pagesPickerVideo);
+  const openAddToFavBatch = useUIShell((s) => s.openAddToFavBatch);
+
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    // 每次 dialog 打开/关闭重置选中
+    if (!open) setSelected(new Set());
+  }, [open]);
+
+  const pages = useMemo(() => video?.pages ?? [], [video]);
+  const totalP = pages.length || video?.videos || 0;
+  const allChecked = selected.size > 0 && selected.size === pages.length;
+  const indeterminate = selected.size > 0 && selected.size < pages.length;
+
+  const toggle = (page: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(page)) next.delete(page);
+      else next.add(page);
+      return next;
+    });
+  };
+
+  const handleToggleAll = () => {
+    if (allChecked) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(pages.map((p) => p.page)));
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!video || selected.size === 0) return;
+    const trackIds = Array.from(selected)
+      .sort((a, b) => a - b)
+      .map((page) => buildTrackId(video.bvid, page));
+    openAddToFavBatch(trackIds);
+    close();
+  };
+
+  if (!video) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => (o ? null : close())}>
+      <DialogContent className="max-w-md">
+        <DialogHeader className="min-w-0">
+          <DialogTitle>选择分 P 添加到歌单</DialogTitle>
+          <DialogDescription className="line-clamp-2 break-words">{video.title}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2">
+          <label className="flex cursor-pointer items-center gap-2 text-sm">
+            <Checkbox
+              checked={indeterminate ? 'indeterminate' : allChecked}
+              onCheckedChange={handleToggleAll}
+              aria-label={allChecked ? '取消全选' : '全选'}
+            />
+            <span>全选</span>
+          </label>
+          <span className="text-xs text-muted-foreground">
+            共 {totalP} P · 已选 {selected.size}
+          </span>
+        </div>
+
+        <div className="max-h-[50vh] overflow-hidden rounded-md border">
+          <PartList
+            pages={pages}
+            activePage={0}
+            onSelect={toggle}
+            selectable
+            selectedPages={selected}
+            onToggleSelect={toggle}
+            hidePinColumn
+            hideActiveHighlight
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={close}>
+            取消
+          </Button>
+          <Button onClick={handleSubmit} disabled={selected.size === 0}>
+            添加 ({selected.size})
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/fav-card.test.tsx
+++ b/packages/web/src/components/fav-card.test.tsx
@@ -47,7 +47,7 @@ function reset() {
   });
   usePlayingListStore.setState({
     favId: '',
-    bvIds: [],
+    trackIds: [],
     current: '',
     playNext: false,
   });
@@ -101,7 +101,7 @@ describe('FavCard', () => {
 
     const state = usePlayingListStore.getState();
     expect(state.favId).toBe('fav-x');
-    expect(state.bvIds).toEqual(['BV1', 'BV2']);
+    expect(state.trackIds).toEqual(['BV1', 'BV2']);
     expect(state.current).toBe('BV1');
     expect(state.playNext).toBe(true);
   });
@@ -293,7 +293,7 @@ describe('FavCard', () => {
 
     const state = usePlayingListStore.getState();
     expect(state.favId).toBe('fav-u');
-    expect(state.bvIds).toEqual(['BV_UP_A', 'BV_UP_B']);
+    expect(state.trackIds).toEqual(['BV_UP_A', 'BV_UP_B']);
     expect(state.current).toBe('BV_UP_A');
     expect(state.playNext).toBe(true);
   });
@@ -340,7 +340,7 @@ describe('FavCard', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: /播放/ }));
-    expect(usePlayingListStore.getState().bvIds).toEqual(['BV_FAV_X']);
+    expect(usePlayingListStore.getState().trackIds).toEqual(['BV_FAV_X']);
   });
 
   it('main 歌单：deletable=false（删除菜单项不渲染）', () => {

--- a/packages/web/src/components/fav-card.test.tsx
+++ b/packages/web/src/components/fav-card.test.tsx
@@ -6,7 +6,10 @@ import {
   usePlayingListStore,
   useUIStore,
   FavListType,
+  MASTER_UP_INFO,
 } from '@shuoshuo-player/shared';
+
+const MASTER_MID = String(MASTER_UP_INFO.mid);
 import { useUIShell } from '@/stores/ui-shell';
 import { FavCard } from './fav-card';
 
@@ -139,15 +142,49 @@ describe('FavCard', () => {
     expect(screen.getByText(/创建于/)).toBeInTheDocument();
   });
 
-  it('UPLOADER 24h 未更新 + store 有 video_list → 自动 readUserVideos(default)', () => {
+  it('master UPLOADER 24h 未更新 + store 有 video_list → 自动 readUserVideos(default)', () => {
     const readUserVideos = vi.fn(async () => {});
     const readUserSpaceInfo = vi.fn(async () => {});
     useBilibiliUserVideosStore.setState({
       readUserVideos,
       readUserSpaceInfo,
       infos: {
-        '999': {
+        [MASTER_MID]: {
           update_time: 0,
+          video_list: [
+            { bvid: 'BV1', created: 0 },
+            { bvid: 'BV2', created: 0 },
+          ],
+          count: 2,
+          update_type: 'default',
+        },
+      },
+      space: {},
+      favFolders: {},
+      isLoading: false,
+    });
+
+    renderCard({
+      favId: 'main',
+      fav: makeFav({
+        type: FavListType.UPLOADER,
+        mid: MASTER_MID,
+        update_time: 0, // 远古时间，触发 24h 阈值
+      }),
+    });
+
+    expect(readUserVideos).toHaveBeenCalledWith(MASTER_MID, 'default');
+    expect(readUserSpaceInfo).toHaveBeenCalledWith(MASTER_MID);
+  });
+
+  it('非 master UPLOADER（其他 UP 主歌单）即使 24h 未更新也不自动 update', () => {
+    const readUserVideos = vi.fn(async () => {});
+    useBilibiliUserVideosStore.setState({
+      readUserVideos,
+      readUserSpaceInfo: vi.fn(async () => {}),
+      infos: {
+        '999': {
+          update_time: 0, // 远古时间，但 mid 非 master，不应触发
           video_list: [
             { bvid: 'BV1', created: 0 },
             { bvid: 'BV2', created: 0 },
@@ -166,15 +203,45 @@ describe('FavCard', () => {
       fav: makeFav({
         type: FavListType.UPLOADER,
         mid: '999',
-        update_time: 0, // 远古时间，触发 24h 阈值
+        update_time: 0,
       }),
     });
 
-    expect(readUserVideos).toHaveBeenCalledWith('999', 'default');
-    expect(readUserSpaceInfo).toHaveBeenCalledWith('999');
+    expect(readUserVideos).not.toHaveBeenCalled();
   });
 
-  it('UPLOADER store 中没有 video_list → 不自动 update（避免新建即拉取）', () => {
+  it('BILI_FAV 即使 24h 未更新也不自动 update（仅 master 自动）', () => {
+    const readUserFavFolderVideos = vi.fn(async () => {});
+    useBilibiliUserVideosStore.setState({
+      readUserVideos: vi.fn(async () => {}),
+      readUserSpaceInfo: vi.fn(async () => {}),
+      readUserFavFolderVideos,
+      infos: {},
+      space: {},
+      favFolders: {
+        '123': {
+          update_time: 0,
+          video_list: [{ bvid: 'BV1', created: 0 }],
+          count: 1,
+          update_type: 'default',
+          info: {},
+        } as never,
+      },
+      isLoading: false,
+    });
+
+    renderCard({
+      favId: 'fav-b',
+      fav: makeFav({
+        type: FavListType.BILI_FAV,
+        biliFavFolderId: '123',
+      }),
+    });
+
+    expect(readUserFavFolderVideos).not.toHaveBeenCalled();
+  });
+
+  it('master UPLOADER store 中没有 video_list → 不自动 update（避免新建即拉取）', () => {
     const readUserVideos = vi.fn(async () => {});
     useBilibiliUserVideosStore.setState({
       readUserVideos,
@@ -186,10 +253,10 @@ describe('FavCard', () => {
     });
 
     renderCard({
-      favId: 'fav-u',
+      favId: 'main',
       fav: makeFav({
         type: FavListType.UPLOADER,
-        mid: '999',
+        mid: MASTER_MID,
       }),
     });
 

--- a/packages/web/src/components/fav-card.tsx
+++ b/packages/web/src/components/fav-card.tsx
@@ -15,14 +15,17 @@ import {
   useBilibiliUserVideosStore,
   useBilibiliVideosStore,
   useFavListStore,
+  useFavoritesStore,
   usePlayingListStore,
   useUIStore,
   formatNumber10K,
   urlPrefixFixed,
   bilibiliThumbUrl,
+  selectSortedBvids,
   timeStampNow,
   FavListType,
   NoticeType,
+  MASTER_UP_INFO,
   VIDEO_LIST_REFRESH_THRESHOLD,
   type FavListItem,
 } from '@shuoshuo-player/shared';
@@ -81,6 +84,7 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
 
   const setPlaylist = usePlayingListStore((s) => s.setPlaylist);
   const removeFavList = useFavListStore((s) => s.removeFavList);
+  const favoritesEntries = useFavoritesStore((s) => s.entries);
   const sendNotice = useUIStore((s) => s.sendNotice);
   const openFavEdit = useUIShell((s) => s.openFavEdit);
   const openAddSong = useUIShell((s) => s.openAddSong);
@@ -91,6 +95,8 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
   const isBiliFav = fav.type === FavListType.BILI_FAV;
   // 系统级「我的收藏」：避免与用户自建 CUSTOM 歌单混淆，统一关闭"自定义"徽标 / 创建时间 / 自定义头像
   const isSystemFavorites = favId === 'favorites';
+  // master UP 主歌单（主数据源）：自动更新仅对其生效
+  const isMasterUploader = isUploader && fav.mid === String(MASTER_UP_INFO.mid);
   // 紧凑模式：UPLOADER 保留 banner（头像 + 统计 + 简介），其他类型压缩为约两行高度
   const isCompact = !isUploader;
   const deletable = favId !== 'main';
@@ -107,6 +113,11 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
    * BILI_FAV 一直是空数组——这是导致"主歌单顶部播放按钮永远 disabled"的根因
    */
   const effectiveBvIds = useMemo<string[]>(() => {
+    // 系统级「我的收藏」：bv_ids 真实数据在 useFavoritesStore.entries（虚拟项 bv_ids 是空数组）
+    // 播放顺序与收藏页默认排序一致：最新收藏在前（desc）
+    if (isSystemFavorites) {
+      return selectSortedBvids(favoritesEntries, 'desc');
+    }
     if (isUploader) {
       return userVideoEntry?.video_list.map((it) => it.bvid) ?? [];
     }
@@ -114,7 +125,15 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
       return favFolder?.video_list.map((it) => it.bvid) ?? [];
     }
     return fav.bv_ids;
-  }, [isUploader, isBiliFav, userVideoEntry, favFolder, fav.bv_ids]);
+  }, [
+    isSystemFavorites,
+    favoritesEntries,
+    isUploader,
+    isBiliFav,
+    userVideoEntry,
+    favFolder,
+    fav.bv_ids,
+  ]);
 
   // 防重入由 store action 入口保证（见 bilibili-user-videos.ts），useCallback 不再依赖 isLoading
   // 让引用稳定，下方 useEffect 才能放心把 updateList 列入 deps
@@ -138,18 +157,17 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
     ],
   );
 
-  // 24h 自动更新检测：仅 UPLOADER / BILI_FAV，且 store 已有 video 数据时（避免新建即拉取）
+  // 24h 自动更新检测：仅 master UP 主歌单（主数据源），其他 UP 主 / B 站收藏夹由用户手动触发更新
+  // 历史问题：原条件覆盖所有 UPLOADER + BILI_FAV，进入任意他人歌单即弹"正在加载投稿列表"，打断用户
   // lastUpdate 取 store 实时值而非 props.fav.update_time —— 后者对 MAIN_FAV_ITEM 写死 0 会永久过期
   const hasVideos = effectiveBvIds.length > 0;
-  const lastUpdate = isUploader
-    ? (userVideoEntry?.update_time ?? 0)
-    : (favFolder?.update_time ?? 0);
+  const masterLastUpdate = userVideoEntry?.update_time ?? 0;
   useEffect(() => {
-    if (!isUploader && !isBiliFav) return;
+    if (!isMasterUploader) return;
     if (!hasVideos) return;
-    if (lastUpdate + VIDEO_LIST_REFRESH_THRESHOLD >= timeStampNow()) return;
+    if (masterLastUpdate + VIDEO_LIST_REFRESH_THRESHOLD >= timeStampNow()) return;
     updateList('default');
-  }, [isUploader, isBiliFav, hasVideos, lastUpdate, updateList]);
+  }, [isMasterUploader, hasVideos, masterLastUpdate, updateList]);
 
   const handlePlay = useCallback(() => {
     if (effectiveBvIds.length === 0) {
@@ -294,6 +312,14 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
                 {space?.name ?? fav.name}
               </h3>
               {!isSystemFavorites && <Badge variant="secondary">{getTypeLabel(fav.type)}</Badge>}
+              <span
+                className={cn(
+                  'shrink-0 text-xs text-muted-foreground',
+                  space?.top_photo && 'text-white/80',
+                )}
+              >
+                共 {effectiveBvIds.length} 首
+              </span>
             </div>
             {!isSystemFavorites && (
               <p
@@ -326,47 +352,50 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
               <PlayCircle className="mr-2 h-4 w-4" />
               播放
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon">
-                  <MoreVertical className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[180px]">
-                {isCustom && (
-                  <DropdownMenuItem onSelect={() => openAddSong(favId)}>
-                    <Plus className="mr-2 h-4 w-4" />
-                    添加歌曲
-                  </DropdownMenuItem>
-                )}
-                {(isUploader || isBiliFav) && (
-                  <>
-                    <DropdownMenuItem onSelect={() => updateList('default')} disabled={isLoading}>
-                      <RefreshCw className="mr-2 h-4 w-4" />
-                      更新前 30
+            {/* 系统级「我的收藏」无编辑/删除/添加等操作，隐藏更多菜单 */}
+            {!isSystemFavorites && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon">
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[180px]">
+                  {isCustom && (
+                    <DropdownMenuItem onSelect={() => openAddSong(favId)}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      添加歌曲
                     </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => updateList('fully')} disabled={isLoading}>
-                      <Star className="mr-2 h-4 w-4" />
-                      更新整个列表
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                  </>
-                )}
-                <DropdownMenuItem onSelect={() => openFavEdit(favId)}>
-                  <Pencil className="mr-2 h-4 w-4" />
-                  编辑歌单
-                </DropdownMenuItem>
-                {deletable && (
-                  <DropdownMenuItem
-                    onSelect={handleDelete}
-                    className="text-destructive focus:text-destructive"
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    删除歌单
+                  )}
+                  {(isUploader || isBiliFav) && (
+                    <>
+                      <DropdownMenuItem onSelect={() => updateList('default')} disabled={isLoading}>
+                        <RefreshCw className="mr-2 h-4 w-4" />
+                        更新前 30
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onSelect={() => updateList('fully')} disabled={isLoading}>
+                        <Star className="mr-2 h-4 w-4" />
+                        更新整个列表
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </>
+                  )}
+                  <DropdownMenuItem onSelect={() => openFavEdit(favId)}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    编辑歌单
                   </DropdownMenuItem>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  {deletable && (
+                    <DropdownMenuItem
+                      onSelect={handleDelete}
+                      className="text-destructive focus:text-destructive"
+                    >
+                      <Trash2 className="mr-2 h-4 w-4" />
+                      删除歌单
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         </div>
       </div>

--- a/packages/web/src/components/fav-card.tsx
+++ b/packages/web/src/components/fav-card.tsx
@@ -89,6 +89,10 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
   const isCustom = fav.type === FavListType.CUSTOM;
   const isUploader = fav.type === FavListType.UPLOADER;
   const isBiliFav = fav.type === FavListType.BILI_FAV;
+  // 系统级「我的收藏」：避免与用户自建 CUSTOM 歌单混淆，统一关闭"自定义"徽标 / 创建时间 / 自定义头像
+  const isSystemFavorites = favId === 'favorites';
+  // 紧凑模式：UPLOADER 保留 banner（头像 + 统计 + 简介），其他类型压缩为约两行高度
+  const isCompact = !isUploader;
   const deletable = favId !== 'main';
 
   const folderInfo = (favFolder?.info ?? {}) as { cover?: string };
@@ -180,9 +184,27 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
   });
 
   const avatar = useMemo(() => {
+    // 紧凑模式（非 UPLOADER）：头像缩到 h-12，避免占用一整行 banner 高度
+    const sizeCls = isCompact ? 'h-12 w-12' : 'h-20 w-20';
+    if (isSystemFavorites) {
+      // 与左侧栏「我的收藏」NavRow 视觉对齐：黄色 Star
+      return (
+        <div
+          className={cn(
+            'flex items-center justify-center rounded-full border-2 border-background bg-yellow-50 shadow dark:bg-yellow-500/10',
+            sizeCls,
+          )}
+          aria-label="我的收藏"
+        >
+          <Star
+            className={cn('fill-yellow-500 text-yellow-500', isCompact ? 'h-6 w-6' : 'h-10 w-10')}
+          />
+        </div>
+      );
+    }
     if (space?.face) {
       return (
-        <Avatar className="h-20 w-20 border-2 border-background shadow">
+        <Avatar className={cn('border-2 border-background shadow', sizeCls)}>
           <AvatarImage src={urlPrefixFixed(space.face)} alt={space.name} />
           <AvatarFallback>{space.name?.[0]}</AvatarFallback>
         </Avatar>
@@ -190,7 +212,7 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
     }
     if (folderInfo.cover) {
       return (
-        <Avatar className="h-20 w-20 border-2 border-background shadow">
+        <Avatar className={cn('border-2 border-background shadow', sizeCls)}>
           <AvatarImage src={urlPrefixFixed(folderInfo.cover)} alt={fav.name} />
           <AvatarFallback>{fav.name?.[0]}</AvatarFallback>
         </Avatar>
@@ -203,7 +225,7 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
       const initial = fav.name ? [...fav.name][0] : '?';
       if (firstVideoCover) {
         return (
-          <Avatar className="h-20 w-20 rounded-md border-2 border-background shadow">
+          <Avatar className={cn('rounded-md border-2 border-background shadow', sizeCls)}>
             <AvatarImage src={bilibiliThumbUrl(firstVideoCover, 200, 200)} alt={fav.name} />
             <AvatarFallback className="rounded-md">{initial}</AvatarFallback>
           </Avatar>
@@ -212,7 +234,11 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
       const hue = stringToHue(fav.id || fav.name || 'fav');
       return (
         <div
-          className="flex h-20 w-20 items-center justify-center rounded-full border-2 border-background text-3xl font-semibold text-white shadow"
+          className={cn(
+            'flex items-center justify-center rounded-full border-2 border-background font-semibold text-white shadow',
+            sizeCls,
+            isCompact ? 'text-base' : 'text-3xl',
+          )}
           style={{
             backgroundImage: `linear-gradient(135deg, hsl(${hue} 70% 60%), hsl(${(hue + 60) % 360} 70% 48%))`,
           }}
@@ -223,13 +249,23 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
       );
     }
     return (
-      <Avatar className="h-20 w-20 border-2 border-background shadow">
+      <Avatar className={cn('border-2 border-background shadow', sizeCls)}>
         <AvatarFallback>
-          <Music className="h-10 w-10 text-muted-foreground" />
+          <Music className={cn('text-muted-foreground', isCompact ? 'h-6 w-6' : 'h-10 w-10')} />
         </AvatarFallback>
       </Avatar>
     );
-  }, [space, folderInfo, fav.name, fav.id, isCustom, isBiliFav, firstVideoCover]);
+  }, [
+    space,
+    folderInfo,
+    fav.name,
+    fav.id,
+    isCustom,
+    isBiliFav,
+    isSystemFavorites,
+    isCompact,
+    firstVideoCover,
+  ]);
 
   const bgStyle = space?.top_photo
     ? {
@@ -247,8 +283,8 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
       )}
       style={bgStyle}
     >
-      <div className="p-6">
-        <div className="flex items-start gap-4">
+      <div className={cn(isCompact ? 'p-3' : 'p-6')}>
+        <div className={cn('flex gap-4', isSystemFavorites ? 'items-center' : 'items-start')}>
           {avatar}
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
@@ -257,17 +293,19 @@ function FavCardImpl({ favId, fav, className }: FavCardProps) {
               >
                 {space?.name ?? fav.name}
               </h3>
-              <Badge variant="secondary">{getTypeLabel(fav.type)}</Badge>
+              {!isSystemFavorites && <Badge variant="secondary">{getTypeLabel(fav.type)}</Badge>}
             </div>
-            <p
-              className={cn(
-                'mt-1 truncate text-sm text-muted-foreground',
-                space?.top_photo && 'text-white/80',
-              )}
-            >
-              {space?.sign ??
-                `创建于 ${dayjs(fav.create_time * 1000).format('YYYY 年 MM 月 DD 日 HH:mm')}`}
-            </p>
+            {!isSystemFavorites && (
+              <p
+                className={cn(
+                  'mt-1 truncate text-sm text-muted-foreground',
+                  space?.top_photo && 'text-white/80',
+                )}
+              >
+                {space?.sign ??
+                  `创建于 ${dayjs(fav.create_time * 1000).format('YYYY 年 MM 月 DD 日 HH:mm')}`}
+              </p>
+            )}
             {space?.stats && (
               <div
                 className={cn(

--- a/packages/web/src/components/layout/nav-menu.test.tsx
+++ b/packages/web/src/components/layout/nav-menu.test.tsx
@@ -146,4 +146,48 @@ describe('NavMenu', () => {
     renderNav(false);
     expect(screen.queryByText('我的歌单')).not.toBeInTheDocument();
   });
+
+  it('展示"我的收藏"链接，指向 /fav/favorites', () => {
+    renderNav(true);
+    const link = screen.getByRole('link', { name: /我的收藏/ });
+    expect(link).toBeInTheDocument();
+    // MemoryRouter 下 href 为 /fav/favorites；HashRouter 下为 #/fav/favorites。统一用 contains
+    expect(link.getAttribute('href')).toMatch(/\/fav\/favorites$/);
+  });
+
+  it('master 歌单（说说Crystal）在 DOM 中位于"我的歌单"分类标题之前', () => {
+    renderNav(true);
+    const masterLink = screen.getByRole('link', { name: /说说Crystal/ });
+    const myFavLabel = screen.getByText('我的歌单');
+    const pos = masterLink.compareDocumentPosition(myFavLabel);
+    // master 在 myFavLabel 之前 → myFavLabel 是 master 的 FOLLOWING
+    expect(pos & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('"我的收藏"在 DOM 中位于"我的歌单"分类标题之后、用户自定义歌单之前', () => {
+    useFavListStore.setState({
+      list: [
+        {
+          id: 'c1',
+          name: '我的精选',
+          type: FavListType.CUSTOM,
+          bv_ids: [],
+          create_time: 0,
+          update_time: 0,
+        } as never,
+      ],
+    });
+    renderNav(true);
+    const myFavLabel = screen.getByText('我的歌单');
+    const favoritesLink = screen.getByRole('link', { name: /我的收藏/ });
+    const customLink = screen.getByRole('link', { name: /我的精选/ });
+    // 标题 → 我的收藏：标题在前
+    expect(
+      myFavLabel.compareDocumentPosition(favoritesLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // 我的收藏 → 自定义：收藏在前
+    expect(
+      favoritesLink.compareDocumentPosition(customLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/packages/web/src/components/layout/nav-menu.tsx
+++ b/packages/web/src/components/layout/nav-menu.tsx
@@ -73,7 +73,7 @@ export function NavMenu({ menuOpen }: NavMenuProps) {
   return (
     <aside
       className={cn(
-        'h-full shrink-0 border-r bg-muted transition-[width] duration-300 dark:bg-background',
+        'h-full shrink-0 bg-muted transition-[width] duration-300 dark:bg-background',
         menuOpen ? 'w-64' : 'w-16',
       )}
       aria-label="侧边导航"

--- a/packages/web/src/components/layout/nav-menu.tsx
+++ b/packages/web/src/components/layout/nav-menu.tsx
@@ -90,17 +90,30 @@ export function NavMenu({ menuOpen }: NavMenuProps) {
 
             <Separator className="my-2" />
 
+            {/* master 歌单单独成行：主 UP 主投稿入口，从「我的歌单」列表中拆出 */}
+            <NavRow
+              item={{
+                to: '/fav/main',
+                label: MASTER_UP_INFO.uname,
+                icon: <Heart className="h-4 w-4 text-rose-500" />,
+              }}
+              collapsed={!menuOpen}
+            />
+
+            <Separator className="my-2" />
+
             {menuOpen && (
               <p className="px-2 pb-1 text-xs uppercase tracking-wide text-muted-foreground">
                 我的歌单
               </p>
             )}
 
+            {/* 系统级「我的收藏」：独立 store，作为「我的歌单」列表第一项 */}
             <NavRow
               item={{
-                to: '/fav/main',
-                label: MASTER_UP_INFO.uname,
-                icon: <Heart className="h-4 w-4 text-rose-500" />,
+                to: '/fav/favorites',
+                label: '我的收藏',
+                icon: <Star className="h-4 w-4 text-yellow-500" />,
               }}
               collapsed={!menuOpen}
             />

--- a/packages/web/src/components/layout/nav-menu.tsx
+++ b/packages/web/src/components/layout/nav-menu.tsx
@@ -103,9 +103,23 @@ export function NavMenu({ menuOpen }: NavMenuProps) {
             <Separator className="my-2" />
 
             {menuOpen && (
-              <p className="px-2 pb-1 text-xs uppercase tracking-wide text-muted-foreground">
-                我的歌单
-              </p>
+              <div className="flex items-center justify-between gap-2 px-2 pb-1">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">我的歌单</p>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                      onClick={() => openFavEdit(null)}
+                      aria-label="创建歌单"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>创建歌单</TooltipContent>
+                </Tooltip>
+              </div>
             )}
 
             {/* 系统级「我的收藏」：独立 store，作为「我的歌单」列表第一项 */}
@@ -130,24 +144,25 @@ export function NavMenu({ menuOpen }: NavMenuProps) {
               />
             ))}
 
-            <Separator className="my-2" />
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className={cn(
-                    'h-9 w-full',
-                    menuOpen ? 'justify-start px-3' : 'justify-center px-0',
-                  )}
-                  onClick={() => openFavEdit(null)}
-                >
-                  <Plus className="h-4 w-4" />
-                  {menuOpen && <span className="ml-2">创建歌单</span>}
-                </Button>
-              </TooltipTrigger>
-              {!menuOpen && <TooltipContent side="right">创建歌单</TooltipContent>}
-            </Tooltip>
+            {/* 折叠态：底部仍保留 Plus 按钮（无标题可挂入口） */}
+            {!menuOpen && (
+              <>
+                <Separator className="my-2" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className="h-9 w-full justify-center px-0"
+                      onClick={() => openFavEdit(null)}
+                      aria-label="创建歌单"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">创建歌单</TooltipContent>
+                </Tooltip>
+              </>
+            )}
           </nav>
         </TooltipProvider>
       </ScrollArea>

--- a/packages/web/src/components/layout/nav-menu.tsx
+++ b/packages/web/src/components/layout/nav-menu.tsx
@@ -73,7 +73,7 @@ export function NavMenu({ menuOpen }: NavMenuProps) {
   return (
     <aside
       className={cn(
-        'h-full shrink-0 border-r bg-background transition-[width] duration-300',
+        'h-full shrink-0 border-r bg-muted transition-[width] duration-300 dark:bg-background',
         menuOpen ? 'w-64' : 'w-16',
       )}
       aria-label="侧边导航"

--- a/packages/web/src/components/layout/player-layout.tsx
+++ b/packages/web/src/components/layout/player-layout.tsx
@@ -1,8 +1,25 @@
-import { useEffect, type ReactNode } from 'react';
-import { usePlayerProfileStore } from '@shuoshuo-player/shared';
+import { useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
+import { getPlatformBridge, usePlayerProfileStore } from '@shuoshuo-player/shared';
 import { useUIShell } from '@/stores/ui-shell';
 import { TopBar } from './top-bar';
 import { NavMenu } from './nav-menu';
+
+/**
+ * macOS Tauri 桌面端启用 titleBarStyle: Overlay 后，应用顶部需要让出 28px
+ * 给系统 traffic light 按钮浮在 viewport 内。其他平台（Web / Chrome 扩展 /
+ * Windows Tauri / Linux Tauri）不需要该安全区。
+ *
+ * 判定时机为模块加载期一次性，PlatformBridge.type 在 init.ts 注入后稳定。
+ */
+function detectMacTrafficLightArea(): boolean {
+  try {
+    if (getPlatformBridge().type !== 'tauri') return false;
+  } catch {
+    return false;
+  }
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return /mac os x/i.test(ua);
+}
 
 interface PlayerLayoutProps {
   /** 主内容区（一般传入 <Outlet />） */
@@ -67,15 +84,27 @@ export function PlayerLayout({ children, footer, overlays }: PlayerLayoutProps) 
     }
   }, [primaryColor]);
 
+  const showMacTrafficLightArea = useMemo(() => detectMacTrafficLightArea(), []);
+  const gridRows = showMacTrafficLightArea
+    ? 'grid-rows-[1.75rem_3.5rem_1fr_5rem]'
+    : 'grid-rows-[3.5rem_1fr_5rem]';
+  const dragRegionStyle = { WebkitAppRegion: 'drag' } as CSSProperties;
+
   return (
-    <div className="grid h-screen grid-rows-[3.5rem_1fr_5rem] overflow-hidden bg-background text-foreground">
+    <div
+      className={`grid h-screen ${gridRows} overflow-hidden bg-muted text-foreground dark:bg-background`}
+    >
+      {/* macOS traffic light 安全区：仅 Tauri + macOS 时占用 row 0；
+          整条 28px 高，shell 色（与 NavMenu / 根背景同色），整体支持拖动 */}
+      {showMacTrafficLightArea && <div style={dragRegionStyle} aria-hidden />}
+
       {/* Row 1: TopBar (3.5rem = h-14) */}
       <TopBar menuOpen={menuOpen} onToggleMenu={toggleMenu} />
 
       {/* Row 2: 中间行，flex 左右布局 NavMenu + main；min-h-0 让 flex 子缩到容器内 */}
       <div className="flex min-h-0 overflow-hidden">
         <NavMenu menuOpen={menuOpen} />
-        <main className="min-w-0 flex-1 overflow-y-auto">
+        <main className="min-w-0 flex-1 overflow-y-auto bg-background dark:bg-muted">
           {/* 不在此处加 padding：让歌词面板等沉浸式视图能贴合 main 边缘；
               普通页面在 RootLayout 自行包 px-6 py-4 */}
           <div className="h-full">{children}</div>

--- a/packages/web/src/components/layout/player-layout.tsx
+++ b/packages/web/src/components/layout/player-layout.tsx
@@ -104,7 +104,7 @@ export function PlayerLayout({ children, footer, overlays }: PlayerLayoutProps) 
       {/* Row 2: 中间行，flex 左右布局 NavMenu + main；min-h-0 让 flex 子缩到容器内 */}
       <div className="flex min-h-0 overflow-hidden">
         <NavMenu menuOpen={menuOpen} />
-        <main className="min-w-0 flex-1 overflow-y-auto bg-background dark:bg-muted">
+        <main className="min-w-0 border-l flex-1 overflow-y-auto bg-background dark:bg-muted">
           {/* 不在此处加 padding：让歌词面板等沉浸式视图能贴合 main 边缘；
               普通页面在 RootLayout 自行包 px-6 py-4 */}
           <div className="h-full">{children}</div>

--- a/packages/web/src/components/layout/top-bar.tsx
+++ b/packages/web/src/components/layout/top-bar.tsx
@@ -253,7 +253,7 @@ export function TopBar({ menuOpen, onToggleMenu }: TopBarProps) {
 
       {/* 右段：标题 + 版本号 + 现有操作；左 + 顶边框 + 左上圆弧自闭合；
           panel 色（light=白 / dark=亮一点黑），与下方 main / footer 同色形成内容区 */}
-      <div className="flex h-full flex-1 items-center gap-2 rounded-tl-lg border-l border-t bg-background px-4 dark:bg-muted">
+      <div className="flex h-full flex-1 items-center gap-2 rounded-tl-xl border-l border-t bg-background px-4 dark:bg-muted">
         <span className="font-semibold tracking-tight">说说播放器</span>
         <span className="text-xs text-muted-foreground">v{APP_VERSION}</span>
         {IS_BETA_VERSION && (

--- a/packages/web/src/components/layout/top-bar.tsx
+++ b/packages/web/src/components/layout/top-bar.tsx
@@ -217,11 +217,12 @@ export function TopBar({ menuOpen, onToggleMenu }: TopBarProps) {
   }, [openConfirm, resetBiliUser, sendNotice]);
 
   return (
-    <header className="z-50 flex h-14 items-center bg-background">
-      {/* 左段：与 NavMenu 同宽切换；border-r 与 NavMenu 边线视觉延续 */}
+    <header className="z-50 flex h-14 items-center">
+      {/* 左段：与 NavMenu 同宽切换；不画 border-r，避免与右段 rounded-tl 圆弧底端衔接错位
+          垂直分隔线由 NavMenu 自身 border-r 在 row2 起承担，圆弧效果更平滑 */}
       <div
         className={cn(
-          'flex h-full shrink-0 items-center border-r transition-[width] duration-300',
+          'flex h-full shrink-0 items-center transition-[width] duration-300',
           menuOpen ? 'w-64 justify-between px-3' : 'w-16 justify-center',
         )}
       >
@@ -250,8 +251,9 @@ export function TopBar({ menuOpen, onToggleMenu }: TopBarProps) {
         )}
       </div>
 
-      {/* 右段：标题 + 版本号 + 现有操作 */}
-      <div className="flex flex-1 items-center gap-2 px-4">
+      {/* 右段：标题 + 版本号 + 现有操作；左 + 顶边框 + 左上圆弧自闭合；
+          panel 色（light=白 / dark=亮一点黑），与下方 main / footer 同色形成内容区 */}
+      <div className="flex h-full flex-1 items-center gap-2 rounded-tl-lg border-l border-t bg-background px-4 dark:bg-muted">
         <span className="font-semibold tracking-tight">说说播放器</span>
         <span className="text-xs text-muted-foreground">v{APP_VERSION}</span>
         {IS_BETA_VERSION && (

--- a/packages/web/src/components/layout/top-bar.tsx
+++ b/packages/web/src/components/layout/top-bar.tsx
@@ -217,7 +217,7 @@ export function TopBar({ menuOpen, onToggleMenu }: TopBarProps) {
   }, [openConfirm, resetBiliUser, sendNotice]);
 
   return (
-    <header className="z-50 flex h-14 items-center border-b bg-background">
+    <header className="z-50 flex h-14 items-center bg-background">
       {/* 左段：与 NavMenu 同宽切换；border-r 与 NavMenu 边线视觉延续 */}
       <div
         className={cn(

--- a/packages/web/src/components/layout/top-bar.tsx
+++ b/packages/web/src/components/layout/top-bar.tsx
@@ -117,6 +117,7 @@ export function TopBar({ menuOpen, onToggleMenu }: TopBarProps) {
             favList: parsed.favList,
             lyricCount: parsed.lyricCount,
             videoCount: parsed.videoCount,
+            favoriteCount: parsed.favoriteCount,
           });
           setImportPayload(parsed.payload);
         } catch {
@@ -149,18 +150,20 @@ export function TopBar({ menuOpen, onToggleMenu }: TopBarProps) {
             fav_list: all.fav_list as never,
             lyrics: all.lyrics as never,
             bili_videos: all.bili_videos as never,
+            favorites: all.favorites as never,
           },
           importPayload,
           mode,
           selectedFavIds,
         );
-        // 仅写回 fav_list / lyrics / bili_videos；其他持久化项（cloud_service /
+        // 仅写回 fav_list / lyrics / bili_videos / favorites；其他持久化项（cloud_service /
         // music_url_cache / playing_list / ui_profile / bili_user_videos）保持原样
         const next = {
           ...all,
           fav_list: merged.fav_list,
           lyrics: merged.lyrics,
           bili_videos: merged.bili_videos,
+          favorites: merged.favorites,
         };
         await storage.setItem(PERSIST_DATA_KEY, JSON.stringify(next));
         setImportSummary(null);

--- a/packages/web/src/components/part-badge.test.tsx
+++ b/packages/web/src/components/part-badge.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { useVideoPagePrefStore, type BilibiliVideo } from '@shuoshuo-player/shared';
+import { PartBadge } from './part-badge';
+
+const BASE: BilibiliVideo = {
+  aid: 1,
+  bvid: 'BV1Test00001',
+  created: 0,
+  length: '',
+  pic: '',
+  is_union_video: false,
+  title: '',
+  sub_title: '',
+  play: 0,
+  comment: 0,
+  author: '',
+  description: '',
+};
+
+describe('PartBadge: 多 P 投稿角标三态', () => {
+  beforeEach(() => {
+    useVideoPagePrefStore.setState({ defaultPage: {} });
+  });
+
+  it('单 P 投稿（videos=1 或缺失）不渲染', () => {
+    const { container, rerender } = render(<PartBadge video={BASE} />);
+    expect(container.firstChild).toBeNull();
+    rerender(<PartBadge video={{ ...BASE, videos: 1 }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('多 P 无偏好：显示 "1/N"（中性灰底）', () => {
+    render(<PartBadge video={{ ...BASE, videos: 4 }} />);
+    const badge = screen.getByLabelText(/共 4P/);
+    expect(badge).toHaveTextContent('1/4');
+    expect(badge.className).toMatch(/bg-muted/);
+  });
+
+  it('多 P 有 defaultPage 偏好：显示 "{n}/{total}"（主色淡底）', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { [BASE.bvid]: 3 } });
+    render(<PartBadge video={{ ...BASE, videos: 4 }} />);
+    const badge = screen.getByLabelText(/默认播放分 P：P3/);
+    expect(badge).toHaveTextContent('3/4');
+    expect(badge.className).toMatch(/bg-primary\/15/);
+  });
+
+  it('显式 explicitPage：显示 "{n}/{total}"（主色边框），优先级高于默认偏好', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { [BASE.bvid]: 3 } });
+    render(<PartBadge video={{ ...BASE, videos: 4 }} explicitPage={2} />);
+    const badge = screen.getByLabelText(/显式分 P：P2/);
+    expect(badge).toHaveTextContent('2/4');
+    expect(badge.className).toMatch(/border-primary\/60/);
+  });
+
+  it('defaultPage 越界（> totalP）退化为 "1/N"（防御性）', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { [BASE.bvid]: 99 } });
+    render(<PartBadge video={{ ...BASE, videos: 4 }} />);
+    expect(screen.getByText('1/4')).toBeInTheDocument();
+  });
+
+  it('explicitPage=1 不渲染显式 P 标识，回退到默认/中性态', () => {
+    // explicitPage=1 是冗余表达（TrackId 永远不会带 :p1），
+    // 但组件应防御性处理：视为无显式 P
+    render(<PartBadge video={{ ...BASE, videos: 3 }} explicitPage={1} />);
+    expect(screen.getByText('1/3')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/part-badge.tsx
+++ b/packages/web/src/components/part-badge.tsx
@@ -1,0 +1,62 @@
+import { useVideoPagePrefStore, type BilibiliVideo } from '@shuoshuo-player/shared';
+import { cn } from '@/lib/utils';
+
+export interface PartBadgeProps {
+  video: BilibiliVideo;
+  /**
+   * 显式 P（来自 TrackId 的 :p<n> 部分）；undefined 表示该条目是纯 bvid，
+   * 角标取决于偏好 store 中的默认 P。
+   */
+  explicitPage?: number;
+  className?: string;
+}
+
+/**
+ * 多 P 视频投稿的角标三态（§5.1 列表语义边界，纯数字版）：
+ *
+ * 视觉强度递增：中性灰（仅信息）→ 主色淡底（已选偏好）→ 主色实边（显式锚定）
+ * 文案统一 `{当前播放 P}/{总 P}`，避免封面小尺寸下中文换行。
+ */
+export function PartBadge({ video, explicitPage, className }: PartBadgeProps) {
+  const totalP = video.videos ?? 1;
+  const defaultPage = useVideoPagePrefStore((s) => s.defaultPage[video.bvid] ?? 1);
+
+  if (totalP <= 1) return null;
+
+  const baseClass = 'rounded px-1 py-0 text-[10px] font-medium leading-tight tabular-nums';
+
+  if (typeof explicitPage === 'number' && explicitPage >= 2) {
+    return (
+      <span
+        className={cn(
+          baseClass,
+          'border border-primary/60 bg-background/85 text-primary',
+          className,
+        )}
+        aria-label={`显式分 P：P${explicitPage} / 共 ${totalP}P`}
+      >
+        {explicitPage}/{totalP}
+      </span>
+    );
+  }
+
+  if (defaultPage >= 2 && defaultPage <= totalP) {
+    return (
+      <span
+        className={cn(baseClass, 'border border-primary/30 bg-primary/15 text-primary', className)}
+        aria-label={`默认播放分 P：P${defaultPage} / 共 ${totalP}P`}
+      >
+        {defaultPage}/{totalP}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(baseClass, 'bg-muted text-muted-foreground', className)}
+      aria-label={`多分 P 视频：共 ${totalP}P，当前默认 1P`}
+    >
+      1/{totalP}
+    </span>
+  );
+}

--- a/packages/web/src/components/player/floating-lyrics.test.tsx
+++ b/packages/web/src/components/player/floating-lyrics.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { usePlayerProfileStore, DEFAULT_FLOATING_LYRICS } from '@shuoshuo-player/shared';
+import { FloatingLyrics } from './floating-lyrics';
+
+function resetCfg() {
+  usePlayerProfileStore.setState({
+    theme: 'light',
+    floatingLyrics: { ...DEFAULT_FLOATING_LYRICS },
+  });
+}
+
+describe('FloatingLyrics', () => {
+  beforeEach(() => {
+    resetCfg();
+  });
+
+  it('visible=false 时不渲染', () => {
+    const { container } = render(<FloatingLyrics line="hello" visible={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('line 为空字符串时不渲染', () => {
+    const { container } = render(<FloatingLyrics line="" visible={true} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('visible+有 line 时渲染文本', () => {
+    render(<FloatingLyrics line="这是一句歌词" visible={true} />);
+    expect(screen.getByText('这是一句歌词')).toBeInTheDocument();
+  });
+
+  it('fontSize / fontWeight 写入 inline style', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ fontSize: 24, fontWeight: 'bold' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    const p = screen.getByText('x');
+    expect(p).toHaveStyle({ fontSize: '24px', fontWeight: '700' });
+  });
+
+  it('fontFamily=serif 时挂 font-serif class', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ fontFamily: 'serif' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByText('x').className).toContain('font-serif');
+  });
+
+  it('fontFamily=mono 时挂 font-mono class', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ fontFamily: 'mono' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByText('x').className).toContain('font-mono');
+  });
+
+  it('textAlign=left 时容器为 justify-start', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ textAlign: 'left' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByTestId('floating-lyrics').className).toContain('justify-start');
+  });
+
+  it('textAlign=right 时容器为 justify-end', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ textAlign: 'right' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByTestId('floating-lyrics').className).toContain('justify-end');
+  });
+
+  it('verticalOffset 通过 bottom:100% + translateY(-Npx) 上抬', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ verticalOffset: 16 });
+    render(<FloatingLyrics line="x" visible={true} />);
+    const el = screen.getByTestId('floating-lyrics');
+    expect(el).toHaveStyle({ bottom: '100%' });
+    expect(el).toHaveStyle({ transform: 'translateY(-16px)' });
+  });
+
+  it('textColor=white 时文字色为 #ffffff', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ textColor: 'white' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByText('x')).toHaveStyle({ color: '#ffffff' });
+  });
+
+  it('textColor=black 时文字色为 #000000', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ textColor: 'black' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByText('x')).toHaveStyle({ color: '#000000' });
+  });
+
+  it('背景固定为黑色（与主题无关）', () => {
+    usePlayerProfileStore.setState({ theme: 'light' });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByText('x')).toHaveStyle({ backgroundColor: '#000000' });
+    usePlayerProfileStore.setState({ theme: 'dark' });
+    expect(screen.getByText('x')).toHaveStyle({ backgroundColor: '#000000' });
+  });
+
+  it('bgOpacity 作为整体 opacity 同时影响文字与背景', () => {
+    usePlayerProfileStore.getState().setFloatingLyrics({ bgOpacity: 0.3 });
+    render(<FloatingLyrics line="x" visible={true} />);
+    expect(screen.getByText('x')).toHaveStyle({ opacity: '0.3' });
+  });
+});

--- a/packages/web/src/components/player/floating-lyrics.tsx
+++ b/packages/web/src/components/player/floating-lyrics.tsx
@@ -1,0 +1,89 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { usePlayerProfileStore, type FloatingLyricsColor } from '@shuoshuo-player/shared';
+import { cn } from '@/lib/utils';
+
+interface FloatingLyricsProps {
+  /** 当前要显示的歌词文本（空字符串视为无歌词） */
+  line: string;
+  /** 父层算好的总开关：cfg.enabled && !showLyric && !!cur && !!line */
+  visible: boolean;
+}
+
+/**
+ * 预设文字色映射；'' 与 'primary' 同义，都跟随主题 --primary。
+ * 用 hsl(var(--primary)) 形式保证 light/dark 主题切换时无需重渲染。
+ */
+const TEXT_COLOR_MAP: Record<FloatingLyricsColor, string> = {
+  '': 'hsl(var(--primary))',
+  primary: 'hsl(var(--primary))',
+  white: '#ffffff',
+  black: '#000000',
+  muted: 'hsl(var(--muted-foreground))',
+};
+
+const ALIGN_CLASS: Record<'left' | 'center' | 'right', string> = {
+  left: 'justify-start',
+  center: 'justify-center',
+  right: 'justify-end',
+};
+
+const FAMILY_CLASS: Record<'sans' | 'serif' | 'mono', string> = {
+  sans: '',
+  serif: 'font-serif',
+  mono: 'font-mono',
+};
+
+/**
+ * 悬浮歌词：footer 上方一行当前歌词条。
+ *
+ * 设计要点：
+ * - 配置统一从 usePlayerProfileStore.floatingLyrics 订阅，父层只传 visible + line
+ *   避免 prop drilling，子组件不依赖 ui-shell。
+ * - 容器 absolute 相对 footer（s-player 的 <footer> 是 relative 锚点），
+ *   bottom 用 inline style 接 verticalOffset，允许用户 0-32 px 微调。
+ * - 背景透明度用 inline backgroundColor + rgba 保底，不用 Tailwind 动态类
+ *   （JIT 不识别 bg-background/${dynamic}）。亮主题用白底、暗主题用黑底。
+ */
+export function FloatingLyrics({ line, visible }: FloatingLyricsProps): ReactElement | null {
+  const cfg = usePlayerProfileStore((s) => s.floatingLyrics);
+
+  if (!visible || !line) return null;
+
+  // bottom: 100% 把元素底边贴在 footer 顶边；translateY(-Npx) 再上推 verticalOffset。
+  // 分两段定位的原因：calc(100% + Npx) 在某些 grid + overflow 嵌套场景下被裁剪/失效，
+  // transform 不参与布局流，无论父容器约束都能保证像素级偏移。
+  const containerStyle: CSSProperties = {
+    bottom: '100%',
+    transform: `translateY(-${cfg.verticalOffset}px)`,
+  };
+
+  // 背景固定黑色，整条共用 cfg.bgOpacity：CSS opacity 同时作用于文字与背景，
+  // 让用户用一个滑块控制"整条歌词条"的不透明度（语义贴近"字体也跟着一起半透明"）。
+  const textStyle: CSSProperties = {
+    fontSize: `${cfg.fontSize}px`,
+    fontWeight: cfg.fontWeight === 'bold' ? 700 : 400,
+    color: TEXT_COLOR_MAP[cfg.textColor],
+    backgroundColor: '#000000',
+    opacity: cfg.bgOpacity,
+    maxWidth: '60%',
+  };
+
+  return (
+    <div
+      className={cn('pointer-events-none absolute inset-x-0 flex px-3', ALIGN_CLASS[cfg.textAlign])}
+      style={containerStyle}
+      aria-hidden
+      data-testid="floating-lyrics"
+    >
+      <p
+        className={cn(
+          'truncate rounded px-3 py-1 leading-tight transition-all',
+          FAMILY_CLASS[cfg.fontFamily],
+        )}
+        style={textStyle}
+      >
+        {line}
+      </p>
+    </div>
+  );
+}

--- a/packages/web/src/components/player/part-list.tsx
+++ b/packages/web/src/components/player/part-list.tsx
@@ -1,0 +1,62 @@
+import { formatPlayTime, type BilibiliVideoPage } from '@shuoshuo-player/shared';
+import { cn } from '@/lib/utils';
+
+interface PartListProps {
+  pages: BilibiliVideoPage[];
+  /** 当前实际播放的 P；非高亮场景传 0 */
+  activePage: number;
+  onSelect: (page: number) => void;
+  /** 容器变体：popover 用于 SPlayer 卡片样式；inline 用于 PlayingQueue 缩进侧线 */
+  variant?: 'popover' | 'inline';
+  className?: string;
+}
+
+/**
+ * 多 P 列表渲染（SPlayer P 选择器与 PlayingQueue 展开复用）。
+ *
+ * 共享语义：P{n} 前缀 + part 标题 + 时长 + 当前 P 高亮 + listbox role / aria-current。
+ * 仅容器样式与 padding 因 variant 切换。
+ */
+export function PartList({
+  pages,
+  activePage,
+  onSelect,
+  variant = 'popover',
+  className,
+}: PartListProps) {
+  const wrapperClass =
+    variant === 'inline'
+      ? 'ml-20 flex flex-col gap-px border-l border-border/60 py-1 pl-2 pr-2 text-xs'
+      : 'flex max-h-72 flex-col gap-px overflow-y-auto';
+  const itemPad = variant === 'inline' ? 'px-2 py-1' : 'px-2 py-1.5 text-sm';
+
+  return (
+    <ul role="listbox" className={cn(wrapperClass, className)}>
+      {pages.map((p) => {
+        const isActive = p.page === activePage;
+        return (
+          <li key={p.cid}>
+            <button
+              type="button"
+              role="option"
+              aria-selected={isActive}
+              onClick={() => onSelect(p.page)}
+              className={cn(
+                'flex w-full items-center gap-2 rounded text-left transition-colors hover:bg-accent',
+                itemPad,
+                isActive && 'bg-primary/15 font-medium text-primary',
+              )}
+              aria-label={`播放 P${p.page}：${p.part || `分P ${p.page}`}`}
+            >
+              <span className="shrink-0 tabular-nums text-muted-foreground">P{p.page}</span>
+              <span className="min-w-0 flex-1 truncate">{p.part || `分P ${p.page}`}</span>
+              <span className="shrink-0 tabular-nums text-xs text-muted-foreground">
+                {formatPlayTime(p.duration)}
+              </span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/web/src/components/player/part-list.tsx
+++ b/packages/web/src/components/player/part-list.tsx
@@ -1,21 +1,39 @@
+import { Pin } from 'lucide-react';
 import { formatPlayTime, type BilibiliVideoPage } from '@shuoshuo-player/shared';
 import { cn } from '@/lib/utils';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
 
-interface PartListProps {
+export interface PartListProps {
   pages: BilibiliVideoPage[];
-  /** 当前实际播放的 P；非高亮场景传 0 */
+  /** 当前实际播放的 P；0 视为不渲染播放高亮 */
   activePage: number;
   onSelect: (page: number) => void;
-  /** 容器变体：popover 用于 SPlayer 卡片样式；inline 用于 PlayingQueue 缩进侧线 */
+  /** popover：SPlayer 控制条卡片；inline：PlayingQueue 折叠缩进 */
   variant?: 'popover' | 'inline';
   className?: string;
+  /* —— 以下 props 仅在 variant='popover' 时生效；inline 保持精简形态 —— */
+  /** 多选模式：行点击改为切勾选 */
+  selectable?: boolean;
+  selectedPages?: Set<number>;
+  onToggleSelect?: (page: number) => void;
+  /** 当前默认 P（>=2 时点亮该行 Pin） */
+  defaultPage?: number;
+  /** 点击 Pin toggle 默认 P；未提供时不渲染 Pin 列 */
+  onTogglePin?: (page: number) => void;
+  /** 整列 Pin 置灰（用于显式 bvid:p<n> 上下文） */
+  pinDisabled?: boolean;
+  pinDisabledReason?: string;
+  /** 显式隐藏 Pin 列（如 PagesPickerDialog 复用场景） */
+  hidePinColumn?: boolean;
+  /** 显式隐藏播放高亮（dialog 场景：不绑定当前播放） */
+  hideActiveHighlight?: boolean;
 }
 
 /**
- * 多 P 列表渲染（SPlayer P 选择器与 PlayingQueue 展开复用）。
- *
- * 共享语义：P{n} 前缀 + part 标题 + 时长 + 当前 P 高亮 + listbox role / aria-current。
- * 仅容器样式与 padding 因 variant 切换。
+ * 多 P 列表渲染：
+ * - popover 变体支持多选 + Pin；inline 变体（PlayingQueue）保持单选 + 精简
+ * - 同源单条渲染避免多处重复
  */
 export function PartList({
   pages,
@@ -23,40 +41,110 @@ export function PartList({
   onSelect,
   variant = 'popover',
   className,
+  selectable = false,
+  selectedPages,
+  onToggleSelect,
+  defaultPage,
+  onTogglePin,
+  pinDisabled = false,
+  pinDisabledReason,
+  hidePinColumn = false,
+  hideActiveHighlight = false,
 }: PartListProps) {
-  const wrapperClass =
-    variant === 'inline'
-      ? 'ml-20 flex flex-col gap-px border-l border-border/60 py-1 pl-2 pr-2 text-xs'
-      : 'flex max-h-72 flex-col gap-px overflow-y-auto';
-  const itemPad = variant === 'inline' ? 'px-2 py-1' : 'px-2 py-1.5 text-sm';
+  const isPopover = variant === 'popover';
+  const showPinColumn = isPopover && !hidePinColumn && typeof onTogglePin === 'function';
+  const showCheckbox = isPopover && selectable;
+
+  const wrapperClass = isPopover
+    ? 'flex max-h-72 flex-col gap-px overflow-y-auto'
+    : 'ml-20 flex flex-col gap-px border-l border-border/60 py-1 pl-2 pr-2 text-xs';
+  const itemPad = isPopover ? 'px-2 py-1.5 text-sm' : 'px-2 py-1';
+
+  const handleRowClick = (page: number) => {
+    if (showCheckbox) onToggleSelect?.(page);
+    else onSelect(page);
+  };
 
   return (
-    <ul role="listbox" className={cn(wrapperClass, className)}>
-      {pages.map((p) => {
-        const isActive = p.page === activePage;
-        return (
-          <li key={p.cid}>
-            <button
-              type="button"
-              role="option"
-              aria-selected={isActive}
-              onClick={() => onSelect(p.page)}
-              className={cn(
-                'flex w-full items-center gap-2 rounded text-left transition-colors hover:bg-accent',
-                itemPad,
-                isActive && 'bg-primary/15 font-medium text-primary',
-              )}
-              aria-label={`播放 P${p.page}：${p.part || `分P ${p.page}`}`}
-            >
-              <span className="shrink-0 tabular-nums text-muted-foreground">P{p.page}</span>
-              <span className="min-w-0 flex-1 truncate">{p.part || `分P ${p.page}`}</span>
-              <span className="shrink-0 tabular-nums text-xs text-muted-foreground">
-                {formatPlayTime(p.duration)}
-              </span>
-            </button>
-          </li>
-        );
-      })}
-    </ul>
+    <TooltipProvider delayDuration={300}>
+      <ul
+        role="listbox"
+        aria-multiselectable={showCheckbox || undefined}
+        className={cn(wrapperClass, className)}
+      >
+        {pages.map((p) => {
+          const isActive = !hideActiveHighlight && p.page === activePage;
+          const isChecked = selectedPages?.has(p.page) ?? false;
+          const isDefault =
+            typeof defaultPage === 'number' && defaultPage >= 2 && defaultPage === p.page;
+          // P1 不能 pin（默认即 P1，冗余）；显式上下文整列置灰
+          const pinUnavailable = pinDisabled || p.page === 1;
+
+          return (
+            <li key={p.cid}>
+              <div
+                role="option"
+                aria-selected={showCheckbox ? isChecked : isActive}
+                onClick={() => handleRowClick(p.page)}
+                className={cn(
+                  'flex w-full cursor-pointer items-center gap-2 rounded text-left transition-colors hover:bg-accent',
+                  itemPad,
+                  isActive && 'bg-primary/15 font-medium text-primary',
+                )}
+                aria-label={`${showCheckbox ? '选择' : '播放'} P${p.page}：${p.part || `分P ${p.page}`}`}
+              >
+                {showCheckbox && (
+                  <span onClick={(e) => e.stopPropagation()} className="flex shrink-0 items-center">
+                    <Checkbox
+                      checked={isChecked}
+                      onCheckedChange={() => onToggleSelect?.(p.page)}
+                      aria-label={isChecked ? `取消选择 P${p.page}` : `选择 P${p.page}`}
+                    />
+                  </span>
+                )}
+                <span className="shrink-0 tabular-nums text-muted-foreground">P{p.page}</span>
+                <span className="min-w-0 flex-1 truncate">{p.part || `分P ${p.page}`}</span>
+                <span className="shrink-0 tabular-nums text-xs text-muted-foreground">
+                  {formatPlayTime(p.duration)}
+                </span>
+                {showPinColumn && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (pinUnavailable) return;
+                          onTogglePin?.(p.page);
+                        }}
+                        disabled={pinUnavailable}
+                        aria-label={isDefault ? `清除默认 P${p.page}` : `设为默认 P${p.page}`}
+                        className={cn(
+                          'inline-flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors',
+                          pinUnavailable
+                            ? 'opacity-30'
+                            : isDefault
+                              ? 'text-primary hover:bg-primary/10'
+                              : 'text-muted-foreground/60 hover:bg-accent hover:text-foreground',
+                        )}
+                      >
+                        <Pin className={cn('h-3.5 w-3.5', isDefault && 'fill-current')} />
+                      </button>
+                    </TooltipTrigger>
+                    {pinUnavailable && (
+                      <TooltipContent>
+                        {pinDisabled
+                          ? (pinDisabledReason ?? '该上下文不支持设置默认 P')
+                          : 'P1 即默认 P，无需固定'}
+                      </TooltipContent>
+                    )}
+                  </Tooltip>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </TooltipProvider>
   );
 }

--- a/packages/web/src/components/player/part-selector.test.tsx
+++ b/packages/web/src/components/player/part-selector.test.tsx
@@ -6,6 +6,7 @@ import {
 } from '@shuoshuo-player/shared';
 import { PartSelector } from './part-selector';
 import { usePlayerRuntimeStore } from '@/stores/player-runtime';
+import { useUIShell } from '@/stores/ui-shell';
 
 const MULTI: BilibiliVideo = {
   aid: 1,
@@ -42,75 +43,108 @@ function resetStores() {
     switchToPage: undefined,
   });
   useVideoPagePrefStore.setState({ defaultPage: {} });
+  useUIShell.setState({
+    addToFavOpen: false,
+    addToFavBvids: [],
+    addToFavExcludeId: null,
+    addToFavFromSearch: false,
+  });
 }
 
 describe('PartSelector', () => {
   beforeEach(resetStores);
 
-  it('列出所有 P + 当前 playingPage 高亮（aria-selected=true）', () => {
+  it('常态 header 显示当前 P + 总 P + 默认 P（如有）', () => {
     usePlayerRuntimeStore.setState({ playingPage: 2 });
+    useVideoPagePrefStore.setState({ defaultPage: { [MULTI.bvid]: 3 } });
     render(<PartSelector video={MULTI} />);
-    expect(screen.getByText('Intro')).toBeInTheDocument();
-    expect(screen.getByText('Verse')).toBeInTheDocument();
-    expect(screen.getByText('Outro')).toBeInTheDocument();
-    expect(screen.getByText(/当前：P2 \/ 共 3 P/)).toBeInTheDocument();
-
-    const p2 = screen.getByRole('option', { selected: true });
-    expect(p2).toHaveTextContent('Verse');
+    expect(screen.getByText(/当前 P2/)).toBeInTheDocument();
+    expect(screen.getByText(/共 3 P/)).toBeInTheDocument();
+    expect(screen.getByText(/默认 P3/)).toBeInTheDocument();
   });
 
-  it('点 P → 调 switchToPage', () => {
+  it('单击 P 行调 switchToPage（常态）', () => {
     const switchToPage = vi.fn();
     usePlayerRuntimeStore.setState({ switchToPage });
     render(<PartSelector video={MULTI} />);
-    fireEvent.click(screen.getByRole('option', { name: /分P 1|Intro/i }));
-    expect(switchToPage).toHaveBeenCalledWith(1);
-    fireEvent.click(screen.getByText('Outro'));
-    expect(switchToPage).toHaveBeenLastCalledWith(3);
+    fireEvent.click(screen.getByRole('option', { name: /播放 P3/ }));
+    expect(switchToPage).toHaveBeenCalledWith(3);
   });
 
-  it('playingPage >= 2 时"设为默认 P"复选框可用', () => {
+  it('点 Pin 按钮 toggle 默认 P', () => {
     usePlayerRuntimeStore.setState({ playingPage: 2 });
     render(<PartSelector video={MULTI} />);
-    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
-    expect(cb).not.toBeDisabled();
-    expect(screen.getByText(/将 P2 设为该投稿的默认 P/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /设为默认 P2/ }));
+    expect(useVideoPagePrefStore.getState().defaultPage[MULTI.bvid]).toBe(2);
   });
 
-  it('playingPage=1 时"设为默认 P"置灰（默认 P 是冗余表达）', () => {
-    usePlayerRuntimeStore.setState({ playingPage: 1 });
+  it('再次点击当前默认行 Pin → 清除', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { [MULTI.bvid]: 2 } });
     render(<PartSelector video={MULTI} />);
-    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
-    expect(cb).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /清除默认 P2/ }));
+    expect(useVideoPagePrefStore.getState().defaultPage[MULTI.bvid]).toBeUndefined();
   });
 
-  it('显式 :p<n> TrackId 上下文：复选框置灰且文案提示', () => {
+  it('P1 行 Pin 按钮 disabled', () => {
+    render(<PartSelector video={MULTI} />);
+    const p1Pin = screen.getByRole('button', { name: /设为默认 P1/ }) as HTMLButtonElement;
+    expect(p1Pin).toBeDisabled();
+  });
+
+  it('显式 :p<n> 上下文整列 Pin 置灰（disabled）', () => {
     usePlayingListStore.setState({
       trackIds: [`${MULTI.bvid}:p2`],
       current: `${MULTI.bvid}:p2`,
     });
-    usePlayerRuntimeStore.setState({ playingPage: 2 });
     render(<PartSelector video={MULTI} />);
-    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
-    expect(cb).toBeDisabled();
-    expect(screen.getByText(/该条目已显式锁定 P/)).toBeInTheDocument();
+    const pinButtons = screen.getAllByRole('button', { name: /(设为默认|清除默认)/ });
+    pinButtons.forEach((btn) => {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    });
   });
 
-  it('勾选"设为默认 P" → 写入 useVideoPagePrefStore', () => {
-    usePlayerRuntimeStore.setState({ playingPage: 3 });
+  it('进入多选模式：header 显示已选 0 + 加入歌单按钮 disabled', () => {
     render(<PartSelector video={MULTI} />);
-    fireEvent.click(screen.getByRole('checkbox'));
-    expect(useVideoPagePrefStore.getState().defaultPage[MULTI.bvid]).toBe(3);
+    fireEvent.click(screen.getByRole('button', { name: '进入多选模式' }));
+    expect(screen.getByText(/已选 0/)).toBeInTheDocument();
+    const addBtn = screen.getByRole('button', { name: /加入歌单 \(0\)/ }) as HTMLButtonElement;
+    expect(addBtn).toBeDisabled();
   });
 
-  it('取消"设为默认 P" → 删 key（回到 page 1 语义）', () => {
-    useVideoPagePrefStore.setState({ defaultPage: { [MULTI.bvid]: 3 } });
-    usePlayerRuntimeStore.setState({ playingPage: 3 });
+  it('多选模式下行点击 = 切勾选；加入歌单 → openAddToFavBatch with trackIds', () => {
+    const openAddToFavBatch = vi.fn();
+    useUIShell.setState({ openAddToFavBatch });
+    const onAfterSubmit = vi.fn();
+    render(<PartSelector video={MULTI} onAfterSubmit={onAfterSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '进入多选模式' }));
+    // 多选模式下行 aria-label 应是"选择"前缀
+    fireEvent.click(screen.getByRole('option', { name: /选择 P1/ }));
+    fireEvent.click(screen.getByRole('option', { name: /选择 P3/ }));
+
+    expect(screen.getByText(/已选 2/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /加入歌单 \(2\)/ }));
+
+    // P1 → 纯 bvid；P3 → bvid:p3
+    expect(openAddToFavBatch).toHaveBeenCalledWith([MULTI.bvid, `${MULTI.bvid}:p3`]);
+    expect(onAfterSubmit).toHaveBeenCalled();
+  });
+
+  it('多选模式全选 / 反选', () => {
     render(<PartSelector video={MULTI} />);
-    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
-    // 初始勾选态：defaultPage[bvid]=3, playingPage=3
-    expect(cb.getAttribute('data-state')).toBe('checked');
-    fireEvent.click(cb);
-    expect(useVideoPagePrefStore.getState().defaultPage[MULTI.bvid]).toBeUndefined();
+    fireEvent.click(screen.getByRole('button', { name: '进入多选模式' }));
+    fireEvent.click(screen.getByRole('button', { name: '全选' }));
+    expect(screen.getByText(/已选 3/)).toBeInTheDocument();
+    // 再点切换为反选（实际全清空）
+    fireEvent.click(screen.getByRole('button', { name: '反选' }));
+    expect(screen.getByText(/已选 0/)).toBeInTheDocument();
+  });
+
+  it('退出多选模式：header 还原 + 选中清空', () => {
+    render(<PartSelector video={MULTI} />);
+    fireEvent.click(screen.getByRole('button', { name: '进入多选模式' }));
+    fireEvent.click(screen.getByRole('option', { name: /选择 P2/ }));
+    fireEvent.click(screen.getByRole('button', { name: '退出多选' }));
+    expect(screen.getByText(/当前 P/)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/player/part-selector.test.tsx
+++ b/packages/web/src/components/player/part-selector.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  usePlayingListStore,
+  useVideoPagePrefStore,
+  type BilibiliVideo,
+} from '@shuoshuo-player/shared';
+import { PartSelector } from './part-selector';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
+
+const MULTI: BilibiliVideo = {
+  aid: 1,
+  bvid: 'BV1Multi00001',
+  created: 0,
+  length: '',
+  pic: '',
+  is_union_video: false,
+  title: 'Multi',
+  sub_title: '',
+  play: 0,
+  comment: 0,
+  author: '',
+  description: '',
+  videos: 3,
+  pages: [
+    { cid: 100, page: 1, part: 'Intro', duration: 60 },
+    { cid: 101, page: 2, part: 'Verse', duration: 90 },
+    { cid: 102, page: 3, part: 'Outro', duration: 30 },
+  ],
+};
+
+function resetStores() {
+  usePlayingListStore.setState({
+    favId: '',
+    trackIds: [MULTI.bvid],
+    current: MULTI.bvid,
+    playNext: false,
+  });
+  usePlayerRuntimeStore.setState({
+    progress: 0,
+    duration: 0,
+    playingPage: 1,
+    switchToPage: undefined,
+  });
+  useVideoPagePrefStore.setState({ defaultPage: {} });
+}
+
+describe('PartSelector', () => {
+  beforeEach(resetStores);
+
+  it('列出所有 P + 当前 playingPage 高亮（aria-selected=true）', () => {
+    usePlayerRuntimeStore.setState({ playingPage: 2 });
+    render(<PartSelector video={MULTI} />);
+    expect(screen.getByText('Intro')).toBeInTheDocument();
+    expect(screen.getByText('Verse')).toBeInTheDocument();
+    expect(screen.getByText('Outro')).toBeInTheDocument();
+    expect(screen.getByText(/当前：P2 \/ 共 3 P/)).toBeInTheDocument();
+
+    const p2 = screen.getByRole('option', { selected: true });
+    expect(p2).toHaveTextContent('Verse');
+  });
+
+  it('点 P → 调 switchToPage', () => {
+    const switchToPage = vi.fn();
+    usePlayerRuntimeStore.setState({ switchToPage });
+    render(<PartSelector video={MULTI} />);
+    fireEvent.click(screen.getByRole('option', { name: /分P 1|Intro/i }));
+    expect(switchToPage).toHaveBeenCalledWith(1);
+    fireEvent.click(screen.getByText('Outro'));
+    expect(switchToPage).toHaveBeenLastCalledWith(3);
+  });
+
+  it('playingPage >= 2 时"设为默认 P"复选框可用', () => {
+    usePlayerRuntimeStore.setState({ playingPage: 2 });
+    render(<PartSelector video={MULTI} />);
+    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
+    expect(cb).not.toBeDisabled();
+    expect(screen.getByText(/将 P2 设为该投稿的默认 P/)).toBeInTheDocument();
+  });
+
+  it('playingPage=1 时"设为默认 P"置灰（默认 P 是冗余表达）', () => {
+    usePlayerRuntimeStore.setState({ playingPage: 1 });
+    render(<PartSelector video={MULTI} />);
+    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
+    expect(cb).toBeDisabled();
+  });
+
+  it('显式 :p<n> TrackId 上下文：复选框置灰且文案提示', () => {
+    usePlayingListStore.setState({
+      trackIds: [`${MULTI.bvid}:p2`],
+      current: `${MULTI.bvid}:p2`,
+    });
+    usePlayerRuntimeStore.setState({ playingPage: 2 });
+    render(<PartSelector video={MULTI} />);
+    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
+    expect(cb).toBeDisabled();
+    expect(screen.getByText(/该条目已显式锁定 P/)).toBeInTheDocument();
+  });
+
+  it('勾选"设为默认 P" → 写入 useVideoPagePrefStore', () => {
+    usePlayerRuntimeStore.setState({ playingPage: 3 });
+    render(<PartSelector video={MULTI} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(useVideoPagePrefStore.getState().defaultPage[MULTI.bvid]).toBe(3);
+  });
+
+  it('取消"设为默认 P" → 删 key（回到 page 1 语义）', () => {
+    useVideoPagePrefStore.setState({ defaultPage: { [MULTI.bvid]: 3 } });
+    usePlayerRuntimeStore.setState({ playingPage: 3 });
+    render(<PartSelector video={MULTI} />);
+    const cb = screen.getByRole('checkbox') as HTMLButtonElement;
+    // 初始勾选态：defaultPage[bvid]=3, playingPage=3
+    expect(cb.getAttribute('data-state')).toBe('checked');
+    fireEvent.click(cb);
+    expect(useVideoPagePrefStore.getState().defaultPage[MULTI.bvid]).toBeUndefined();
+  });
+});

--- a/packages/web/src/components/player/part-selector.tsx
+++ b/packages/web/src/components/player/part-selector.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import {
+  parseTrackId,
+  usePlayingListStore,
+  useVideoPagePrefStore,
+  type BilibiliVideo,
+} from '@shuoshuo-player/shared';
+import { cn } from '@/lib/utils';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
+import { PartList } from './part-list';
+
+interface PartSelectorProps {
+  video: BilibiliVideo;
+}
+
+/**
+ * SPlayer 控制条上的 P 选择器（Popover 内容）。
+ *
+ * 行为约束（§5.2）：
+ * - 列出 video.pages 所有 P + 时长，当前实际播放 P 高亮
+ * - 点击切 P → 调 switchToPage（不改 store.current）
+ * - "设为默认 P" 复选框：
+ *   - 显式 TrackId 上下文（current 含 :p<n>）置灰 — 显式条目已锚定 P，偏好不再适用
+ *   - 状态 = (defaultPage[bvid] === playingPage 且 playingPage >= 2)
+ *   - 勾选 → setDefaultPage(bvid, playingPage)
+ *   - 取消 → setDefaultPage(bvid, 1)（store 内部会删 key）
+ */
+export function PartSelector({ video }: PartSelectorProps) {
+  const pages = video.pages ?? [];
+  const totalP = video.videos ?? pages.length;
+  const currentTrackId = usePlayingListStore((s) => s.current);
+  const playingPage = usePlayerRuntimeStore((s) => s.playingPage);
+  const switchToPage = usePlayerRuntimeStore((s) => s.switchToPage);
+  const defaultPage = useVideoPagePrefStore((s) => s.defaultPage[video.bvid] ?? 1);
+  const setDefaultPage = useVideoPagePrefStore((s) => s.setDefaultPage);
+
+  // 是否显式 TrackId（含 :p<n>）—— 决定"设为默认 P"是否可用
+  const isExplicit = useMemo(() => {
+    const parsed = parseTrackId(currentTrackId);
+    return parsed?.page !== undefined;
+  }, [currentTrackId]);
+
+  // 默认 P 复选框选中态：当且仅当 playingPage >= 2 且与 defaultPage 一致
+  const setAsDefaultChecked = playingPage >= 2 && defaultPage === playingPage;
+  const setAsDefaultDisabled = isExplicit || playingPage < 2;
+
+  const handleToggleDefault = (next: boolean) => {
+    if (setAsDefaultDisabled) return;
+    setDefaultPage(video.bvid, next ? playingPage : 1);
+  };
+
+  return (
+    <div className="flex w-72 flex-col gap-1 p-1" aria-label="分 P 选择器">
+      <div className="px-2 py-1 text-xs text-muted-foreground">
+        当前：P{playingPage} / 共 {totalP} P
+      </div>
+      <PartList pages={pages} activePage={playingPage} onSelect={(page) => switchToPage?.(page)} />
+      <div
+        className={cn(
+          'mt-1 flex items-center gap-2 border-t px-2 pt-2',
+          setAsDefaultDisabled && 'opacity-50',
+        )}
+      >
+        <Checkbox
+          id="set-as-default-page"
+          checked={setAsDefaultChecked}
+          disabled={setAsDefaultDisabled}
+          onCheckedChange={(v) => handleToggleDefault(v === true)}
+          aria-label="将当前 P 设为该投稿的默认 P"
+        />
+        <Label
+          htmlFor="set-as-default-page"
+          className={cn('text-xs', setAsDefaultDisabled ? 'cursor-not-allowed' : 'cursor-pointer')}
+        >
+          {isExplicit ? '该条目已显式锁定 P，不可改默认' : `将 P${playingPage} 设为该投稿的默认 P`}
+        </Label>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/player/part-selector.tsx
+++ b/packages/web/src/components/player/part-selector.tsx
@@ -1,33 +1,34 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { ListChecks, Plus, X } from 'lucide-react';
 import {
-  parseTrackId,
+  buildTrackId,
+  isExplicitPageTrackId,
   usePlayingListStore,
   useVideoPagePrefStore,
   type BilibiliVideo,
 } from '@shuoshuo-player/shared';
 import { cn } from '@/lib/utils';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
 import { usePlayerRuntimeStore } from '@/stores/player-runtime';
+import { useUIShell } from '@/stores/ui-shell';
 import { PartList } from './part-list';
 
 interface PartSelectorProps {
   video: BilibiliVideo;
+  /** 加入歌单提交后 / 退多选关 popover 的回调（由父组件控制 Popover open 状态） */
+  onAfterSubmit?: () => void;
 }
 
 /**
- * SPlayer 控制条上的 P 选择器（Popover 内容）。
+ * SPlayer 控制条 P 选择 Popover 内容。
  *
- * 行为约束（§5.2）：
- * - 列出 video.pages 所有 P + 时长，当前实际播放 P 高亮
- * - 点击切 P → 调 switchToPage（不改 store.current）
- * - "设为默认 P" 复选框：
- *   - 显式 TrackId 上下文（current 含 :p<n>）置灰 — 显式条目已锚定 P，偏好不再适用
- *   - 状态 = (defaultPage[bvid] === playingPage 且 playingPage >= 2)
- *   - 勾选 → setDefaultPage(bvid, playingPage)
- *   - 取消 → setDefaultPage(bvid, 1)（store 内部会删 key）
+ * 常态：单击行切 P 播放；Pin 列点击切换默认 P 偏好。
+ * 多选模式：行点击改为切勾选；底部"加入歌单(N)"批量加入。
+ *
+ * 与 useVideoPagePrefStore / usePlayerRuntimeStore.switchToPage / useUIShell.openAddToFavBatch
+ * 解耦：所有状态都通过既有 store API 操作。
  */
-export function PartSelector({ video }: PartSelectorProps) {
+export function PartSelector({ video, onAfterSubmit }: PartSelectorProps) {
   const pages = video.pages ?? [];
   const totalP = video.videos ?? pages.length;
   const currentTrackId = usePlayingListStore((s) => s.current);
@@ -35,48 +36,123 @@ export function PartSelector({ video }: PartSelectorProps) {
   const switchToPage = usePlayerRuntimeStore((s) => s.switchToPage);
   const defaultPage = useVideoPagePrefStore((s) => s.defaultPage[video.bvid] ?? 1);
   const setDefaultPage = useVideoPagePrefStore((s) => s.setDefaultPage);
+  const openAddToFavBatch = useUIShell((s) => s.openAddToFavBatch);
 
-  // 是否显式 TrackId（含 :p<n>）—— 决定"设为默认 P"是否可用
-  const isExplicit = useMemo(() => {
-    const parsed = parseTrackId(currentTrackId);
-    return parsed?.page !== undefined;
-  }, [currentTrackId]);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
 
-  // 默认 P 复选框选中态：当且仅当 playingPage >= 2 且与 defaultPage 一致
-  const setAsDefaultChecked = playingPage >= 2 && defaultPage === playingPage;
-  const setAsDefaultDisabled = isExplicit || playingPage < 2;
+  const isExplicit = useMemo(() => isExplicitPageTrackId(currentTrackId), [currentTrackId]);
 
-  const handleToggleDefault = (next: boolean) => {
-    if (setAsDefaultDisabled) return;
-    setDefaultPage(video.bvid, next ? playingPage : 1);
+  const toggleSelect = (page: number) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(page)) next.delete(page);
+      else next.add(page);
+      return next;
+    });
+  };
+
+  const handleEnterSelect = () => {
+    setSelectMode(true);
+    setSelected(new Set());
+  };
+
+  const handleExitSelect = () => {
+    setSelectMode(false);
+    setSelected(new Set());
+  };
+
+  const handleToggleAll = () => {
+    if (selected.size === pages.length) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(pages.map((p) => p.page)));
+    }
+  };
+
+  const handleTogglePin = (page: number) => {
+    if (defaultPage === page) {
+      setDefaultPage(video.bvid, 1);
+    } else {
+      setDefaultPage(video.bvid, page);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (selected.size === 0) return;
+    const trackIds = Array.from(selected)
+      .sort((a, b) => a - b)
+      .map((page) => buildTrackId(video.bvid, page));
+    openAddToFavBatch(trackIds);
+    handleExitSelect();
+    onAfterSubmit?.();
   };
 
   return (
-    <div className="flex w-72 flex-col gap-1 p-1" aria-label="分 P 选择器">
-      <div className="px-2 py-1 text-xs text-muted-foreground">
-        当前：P{playingPage} / 共 {totalP} P
-      </div>
-      <PartList pages={pages} activePage={playingPage} onSelect={(page) => switchToPage?.(page)} />
-      <div
-        className={cn(
-          'mt-1 flex items-center gap-2 border-t px-2 pt-2',
-          setAsDefaultDisabled && 'opacity-50',
-        )}
-      >
-        <Checkbox
-          id="set-as-default-page"
-          checked={setAsDefaultChecked}
-          disabled={setAsDefaultDisabled}
-          onCheckedChange={(v) => handleToggleDefault(v === true)}
-          aria-label="将当前 P 设为该投稿的默认 P"
-        />
-        <Label
-          htmlFor="set-as-default-page"
-          className={cn('text-xs', setAsDefaultDisabled ? 'cursor-not-allowed' : 'cursor-pointer')}
-        >
-          {isExplicit ? '该条目已显式锁定 P，不可改默认' : `将 P${playingPage} 设为该投稿的默认 P`}
-        </Label>
-      </div>
+    <div className="flex w-72 flex-col gap-0 p-1" aria-label="分 P 选择器">
+      {/* Header */}
+      {selectMode ? (
+        <div className="flex items-center gap-1 border-b px-1 py-1">
+          <span className="shrink-0 text-xs text-muted-foreground">已选 {selected.size}</span>
+          <button
+            type="button"
+            onClick={handleToggleAll}
+            className="rounded px-1.5 py-0.5 text-xs text-primary hover:bg-accent"
+          >
+            {selected.size === pages.length ? '反选' : '全选'}
+          </button>
+          <div className="flex-1" />
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={selected.size === 0}
+            className="h-6 gap-1 px-2 text-xs"
+          >
+            <Plus className="h-3 w-3" />
+            加入歌单 ({selected.size})
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={handleExitSelect}
+            className="h-6 w-6"
+            aria-label="退出多选"
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-2 border-b px-2 py-1.5">
+          <span className="text-xs text-muted-foreground">
+            当前 P{playingPage} · 共 {totalP} P
+            {defaultPage >= 2 && <span className="ml-1 text-primary">· 默认 P{defaultPage}</span>}
+          </span>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={handleEnterSelect}
+            className="h-6 w-6"
+            aria-label="进入多选模式"
+          >
+            <ListChecks className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      )}
+
+      {/* P 列表（依赖 PartList 多选 + Pin 支持） */}
+      <PartList
+        pages={pages}
+        activePage={playingPage}
+        onSelect={(page) => switchToPage?.(page)}
+        selectable={selectMode}
+        selectedPages={selected}
+        onToggleSelect={toggleSelect}
+        defaultPage={defaultPage}
+        onTogglePin={handleTogglePin}
+        pinDisabled={isExplicit}
+        pinDisabledReason="当前条目已显式锁定 P，默认 P 不适用"
+        className={cn('mt-1', selectMode && 'mt-0')}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/player/playing-queue.test.tsx
+++ b/packages/web/src/components/player/playing-queue.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useBilibiliVideosStore, usePlayingListStore } from '@shuoshuo-player/shared';
 import { PlayingQueue } from './playing-queue';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
 
 class MockResizeObserver {
   observe = vi.fn();
@@ -11,7 +12,7 @@ class MockResizeObserver {
 function reset() {
   usePlayingListStore.setState({
     favId: '',
-    bvIds: [],
+    trackIds: [],
     current: '',
     playNext: false,
   });
@@ -58,7 +59,7 @@ describe('PlayingQueue', () => {
     expect(screen.getByRole('heading', { level: 3, name: '播放队列' })).toBeInTheDocument();
   });
 
-  it('队列有曲目时按 bvIds 顺序渲染', () => {
+  it('队列有曲目时按 trackIds 顺序渲染', () => {
     useBilibiliVideosStore.setState({
       ids: ['BV1', 'BV2'],
       entities: {
@@ -66,7 +67,7 @@ describe('PlayingQueue', () => {
         BV2: { bvid: 'BV2', title: 'Track B', pic: '' } as never,
       },
     });
-    usePlayingListStore.setState({ bvIds: ['BV1', 'BV2'], current: 'BV1' });
+    usePlayingListStore.setState({ trackIds: ['BV1', 'BV2'], current: 'BV1' });
 
     render(<PlayingQueue open onOpenChange={vi.fn()} />);
     expect(screen.getByText('共 2 首')).toBeInTheDocument();
@@ -82,7 +83,7 @@ describe('PlayingQueue', () => {
         BV2: { bvid: 'BV2', title: 'Track B', pic: '' } as never,
       },
     });
-    usePlayingListStore.setState({ bvIds: ['BV1', 'BV2'], current: 'BV1' });
+    usePlayingListStore.setState({ trackIds: ['BV1', 'BV2'], current: 'BV1' });
 
     render(<PlayingQueue open onOpenChange={vi.fn()} />);
     fireEvent.click(screen.getByText('Track B').closest('div[data-bv]')!);
@@ -92,7 +93,7 @@ describe('PlayingQueue', () => {
   });
 
   it('点击清空按钮 → clearPlaylist', () => {
-    usePlayingListStore.setState({ bvIds: ['BV1'], current: 'BV1' });
+    usePlayingListStore.setState({ trackIds: ['BV1'], current: 'BV1' });
     useBilibiliVideosStore.setState({
       ids: ['BV1'],
       entities: { BV1: { bvid: 'BV1', title: 'A', pic: '' } as never },
@@ -102,7 +103,7 @@ describe('PlayingQueue', () => {
     fireEvent.click(screen.getByRole('button', { name: /清空/ }));
 
     const state = usePlayingListStore.getState();
-    expect(state.bvIds).toEqual([]);
+    expect(state.trackIds).toEqual([]);
     expect(state.current).toBe('');
   });
 
@@ -125,5 +126,170 @@ describe('PlayingQueue', () => {
     render(<PlayingQueue open onOpenChange={vi.fn()} />);
     // 窄屏 SheetContent 应有 h-[60vh] class（vs 宽屏的 w-[400px]）
     expect(document.body.querySelector('[class*="h-\\[60vh\\]"]')).toBeTruthy();
+  });
+});
+
+describe('PlayingQueue: 多 P 投稿折叠展开（C3）', () => {
+  beforeEach(() => {
+    reset();
+    usePlayerRuntimeStore.setState({ playingPage: 1, switchToPage: undefined });
+  });
+
+  const MULTI_BV = 'BV1Multi00001';
+  const setupMulti = () => {
+    useBilibiliVideosStore.setState({
+      ids: [MULTI_BV],
+      entities: {
+        [MULTI_BV]: {
+          aid: 1,
+          bvid: MULTI_BV,
+          created: 0,
+          length: '',
+          pic: '',
+          is_union_video: false,
+          title: 'Multi Track',
+          sub_title: '',
+          play: 0,
+          comment: 0,
+          author: 'Up',
+          description: '',
+          videos: 3,
+          pages: [
+            { cid: 100, page: 1, part: 'Intro', duration: 60 },
+            { cid: 101, page: 2, part: 'Verse', duration: 90 },
+            { cid: 102, page: 3, part: 'Outro', duration: 30 },
+          ],
+        },
+      },
+    });
+  };
+
+  it('多 P 投稿（纯 bvid）渲染展开按钮 + 标题后显示 NP', () => {
+    setupMulti();
+    usePlayingListStore.setState({ trackIds: [MULTI_BV], current: MULTI_BV });
+    render(<PlayingQueue open onOpenChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: '展开分 P' })).toBeInTheDocument();
+    expect(screen.getByText(/3P/)).toBeInTheDocument();
+  });
+
+  it('单 P 投稿不渲染展开按钮', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1Single'],
+      entities: {
+        BV1Single: {
+          aid: 1,
+          bvid: 'BV1Single',
+          created: 0,
+          length: '',
+          pic: '',
+          is_union_video: false,
+          title: 'Single',
+          sub_title: '',
+          play: 0,
+          comment: 0,
+          author: 'Up',
+          description: '',
+        },
+      },
+    });
+    usePlayingListStore.setState({ trackIds: ['BV1Single'], current: 'BV1Single' });
+    render(<PlayingQueue open onOpenChange={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /展开分 P/ })).toBeNull();
+  });
+
+  it('显式 :p<n> 条目不渲染展开按钮，但显示 P 标识', () => {
+    setupMulti();
+    const explicitTrack = `${MULTI_BV}:p2`;
+    usePlayingListStore.setState({ trackIds: [explicitTrack], current: explicitTrack });
+    render(<PlayingQueue open onOpenChange={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /展开分 P/ })).toBeNull();
+    // 标题旁有 P2 显式标识
+    expect(screen.getByText('P2')).toBeInTheDocument();
+  });
+
+  it('点展开按钮 → 列出所有 P + 当前播放 P 高亮', () => {
+    setupMulti();
+    usePlayingListStore.setState({ trackIds: [MULTI_BV], current: MULTI_BV });
+    usePlayerRuntimeStore.setState({ playingPage: 2 });
+    render(<PlayingQueue open onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '展开分 P' }));
+
+    expect(screen.getByText('Intro')).toBeInTheDocument();
+    expect(screen.getByText('Verse')).toBeInTheDocument();
+    expect(screen.getByText('Outro')).toBeInTheDocument();
+
+    // playingPage=2 的 P 高亮（aria-selected）
+    const p2Btn = screen.getByRole('option', { name: /播放 P2/ });
+    expect(p2Btn.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('点 P 调 switchToPage 而不动 store.current', () => {
+    setupMulti();
+    const switchToPage = vi.fn();
+    usePlayingListStore.setState({ trackIds: [MULTI_BV], current: MULTI_BV });
+    usePlayerRuntimeStore.setState({ switchToPage });
+    render(<PlayingQueue open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: '展开分 P' }));
+
+    fireEvent.click(screen.getByRole('option', { name: /播放 P3/ }));
+
+    expect(switchToPage).toHaveBeenCalledWith(3);
+    // store.current 不变
+    expect(usePlayingListStore.getState().current).toBe(MULTI_BV);
+  });
+
+  it('非当前播放条目展开后点 P：先把该条目设为 current，再 switchToPage', () => {
+    useBilibiliVideosStore.setState({
+      ids: [MULTI_BV, 'BV1Other'],
+      entities: {
+        [MULTI_BV]: {
+          aid: 1,
+          bvid: MULTI_BV,
+          created: 0,
+          length: '',
+          pic: '',
+          is_union_video: false,
+          title: 'Multi',
+          sub_title: '',
+          play: 0,
+          comment: 0,
+          author: 'Up',
+          description: '',
+          videos: 2,
+          pages: [
+            { cid: 100, page: 1, part: 'A', duration: 60 },
+            { cid: 101, page: 2, part: 'B', duration: 90 },
+          ],
+        },
+        BV1Other: {
+          aid: 2,
+          bvid: 'BV1Other',
+          created: 0,
+          length: '',
+          pic: '',
+          is_union_video: false,
+          title: 'Other',
+          sub_title: '',
+          play: 0,
+          comment: 0,
+          author: '',
+          description: '',
+        },
+      },
+    });
+    const switchToPage = vi.fn();
+    usePlayingListStore.setState({
+      trackIds: ['BV1Other', MULTI_BV],
+      current: 'BV1Other',
+    });
+    usePlayerRuntimeStore.setState({ switchToPage });
+
+    render(<PlayingQueue open onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: '展开分 P' }));
+    fireEvent.click(screen.getByRole('option', { name: /播放 P2/ }));
+
+    expect(usePlayingListStore.getState().current).toBe(MULTI_BV);
+    expect(switchToPage).toHaveBeenCalledWith(2);
   });
 });

--- a/packages/web/src/components/player/playing-queue.tsx
+++ b/packages/web/src/components/player/playing-queue.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Trash2, X } from 'lucide-react';
+import { ChevronDown, Trash2, X } from 'lucide-react';
 import {
   useBilibiliVideosStore,
   usePlayingListStore,
   bilibiliThumbUrl,
+  parseTrackId,
+  type BilibiliVideo,
 } from '@shuoshuo-player/shared';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -15,6 +17,8 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@/components/ui/sheet';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
+import { PartList } from './part-list';
 
 interface PlayingQueueProps {
   open: boolean;
@@ -23,18 +27,33 @@ interface PlayingQueueProps {
 
 const NARROW_QUERY = '(max-width: 1024px)';
 
+interface QueueRow {
+  trackId: string;
+  bvid: string;
+  explicitPage?: number;
+  video?: BilibiliVideo;
+}
+
 /**
  * 播放队列：宽屏右侧 Sheet，窄屏底部 Sheet（避免 Popover virtualRef 兼容问题）。
+ *
+ * 自 C3 起支持多 P 投稿的折叠展开：
+ * - 纯 bvid 多 P 投稿在尾部加 ▾ 折叠按钮，展开后列出所有 P
+ * - 显式 :p<n> 条目不展开（已是单 P）
+ * - 点击展开行的 P → 调 usePlayerRuntimeStore.switchToPage(n)，不动 queue.trackIds
  */
 export function PlayingQueue({ open, onOpenChange }: PlayingQueueProps) {
-  const bvIds = usePlayingListStore((s) => s.bvIds);
-  const currentBvId = usePlayingListStore((s) => s.current);
+  const trackIds = usePlayingListStore((s) => s.trackIds);
+  const currentTrackId = usePlayingListStore((s) => s.current);
   const updateCurrentPlaying = usePlayingListStore((s) => s.updateCurrentPlaying);
   const removeItem = usePlayingListStore((s) => s.removeItem);
   const clearPlaylist = usePlayingListStore((s) => s.clearPlaylist);
   const videoEntities = useBilibiliVideosStore((s) => s.entities);
+  const playingPage = usePlayerRuntimeStore((s) => s.playingPage);
+  const switchToPage = usePlayerRuntimeStore((s) => s.switchToPage);
 
   const [isNarrow, setIsNarrow] = useState(false);
+  const [expandedTracks, setExpandedTracks] = useState<Set<string>>(new Set());
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -47,22 +66,41 @@ export function PlayingQueue({ open, onOpenChange }: PlayingQueueProps) {
 
   // 打开后延迟 100ms 滚动到当前曲目
   useEffect(() => {
-    if (!open || !currentBvId) return;
+    if (!open || !currentTrackId) return;
     const timer = setTimeout(() => {
-      const el = listRef.current?.querySelector<HTMLElement>(`[data-bv="${currentBvId}"]`);
+      const el = listRef.current?.querySelector<HTMLElement>(`[data-bv="${currentTrackId}"]`);
       el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
     }, 100);
     return () => clearTimeout(timer);
-  }, [open, currentBvId]);
+  }, [open, currentTrackId]);
 
-  const handlePlayAt = (bvid: string) => {
-    const idx = bvIds.indexOf(bvid);
+  const handlePlayAt = (trackId: string) => {
+    const idx = trackIds.indexOf(trackId);
     if (idx >= 0) updateCurrentPlaying(idx, true);
   };
 
-  const list = useMemo(
-    () => bvIds.map((id) => ({ bvid: id, video: videoEntities[id] })),
-    [bvIds, videoEntities],
+  const toggleExpand = (trackId: string) => {
+    setExpandedTracks((prev) => {
+      const next = new Set(prev);
+      if (next.has(trackId)) next.delete(trackId);
+      else next.add(trackId);
+      return next;
+    });
+  };
+
+  const list = useMemo<QueueRow[]>(
+    () =>
+      trackIds.map((id) => {
+        const parsed = parseTrackId(id);
+        const bvid = parsed?.bvid ?? id;
+        return {
+          trackId: id,
+          bvid,
+          explicitPage: parsed?.page,
+          video: videoEntities[bvid],
+        };
+      }),
+    [trackIds, videoEntities],
   );
 
   return (
@@ -80,13 +118,13 @@ export function PlayingQueue({ open, onOpenChange }: PlayingQueueProps) {
           <div className="flex items-center justify-between gap-2 border-b px-4 py-3 pr-12">
             <div className="min-w-0 flex-1">
               <h3 className="truncate text-base font-semibold">播放队列</h3>
-              <p className="truncate text-xs text-muted-foreground">共 {bvIds.length} 首</p>
+              <p className="truncate text-xs text-muted-foreground">共 {trackIds.length} 首</p>
             </div>
             <Button
               variant="outline"
               size="sm"
               onClick={clearPlaylist}
-              disabled={bvIds.length === 0}
+              disabled={trackIds.length === 0}
               className="h-7 shrink-0 gap-1 border-destructive/40 px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive focus-visible:ring-offset-0"
             >
               <Trash2 className="h-3.5 w-3.5" />
@@ -101,53 +139,97 @@ export function PlayingQueue({ open, onOpenChange }: PlayingQueueProps) {
               {list.length === 0 && (
                 <p className="px-3 py-8 text-center text-sm text-muted-foreground">队列为空</p>
               )}
-              {list.map(({ bvid, video }) => {
-                const isCurrent = bvid === currentBvId;
+              {list.map(({ trackId, bvid, explicitPage, video }) => {
+                const isCurrent = trackId === currentTrackId;
+                const totalP = video?.videos ?? 1;
+                // 仅纯 bvid + 多 P 投稿才支持折叠展开（显式 :p<n> 已锚定单 P）
+                const isExpandable = totalP > 1 && explicitPage === undefined;
+                const isExpanded = isExpandable && expandedTracks.has(trackId);
                 return (
-                  <div
-                    key={bvid}
-                    data-bv={bvid}
-                    className={cn(
-                      'flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-accent',
-                      isCurrent && 'bg-accent',
-                    )}
-                    onClick={() => handlePlayAt(bvid)}
-                  >
-                    {video?.pic ? (
-                      <img
-                        src={bilibiliThumbUrl(video.pic, 160, 100)}
-                        alt=""
-                        loading="lazy"
-                        className="h-10 w-16 shrink-0 rounded object-cover"
-                      />
-                    ) : (
-                      <div className="h-10 w-16 shrink-0 rounded bg-muted" />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <p
-                        className={cn(
-                          'truncate text-sm',
-                          isCurrent && 'font-semibold text-primary',
-                        )}
-                      >
-                        {video?.title ?? bvid}
-                      </p>
-                      <p className="truncate text-xs text-muted-foreground">
-                        {video?.author ?? ''}
-                      </p>
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 shrink-0"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        removeItem(bvid);
-                      }}
-                      aria-label="移除"
+                  <div key={trackId}>
+                    <div
+                      data-bv={trackId}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-accent',
+                        isCurrent && 'bg-accent',
+                      )}
+                      onClick={() => handlePlayAt(trackId)}
                     >
-                      <X className="h-4 w-4" />
-                    </Button>
+                      {video?.pic ? (
+                        <img
+                          src={bilibiliThumbUrl(video.pic, 160, 100)}
+                          alt=""
+                          loading="lazy"
+                          className="h-10 w-16 shrink-0 rounded object-cover"
+                        />
+                      ) : (
+                        <div className="h-10 w-16 shrink-0 rounded bg-muted" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p
+                          className={cn(
+                            'truncate text-sm',
+                            isCurrent && 'font-semibold text-primary',
+                          )}
+                        >
+                          {video?.title ?? bvid}
+                          {explicitPage !== undefined && (
+                            <span className="ml-1 rounded border border-primary/60 px-1 py-0 text-[10px] leading-tight text-primary">
+                              P{explicitPage}
+                            </span>
+                          )}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {video?.author ?? ''}
+                          {totalP > 1 && explicitPage === undefined && (
+                            <span className="ml-1 text-[10px]">· {totalP}P</span>
+                          )}
+                        </p>
+                      </div>
+                      {isExpandable && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 shrink-0"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleExpand(trackId);
+                          }}
+                          aria-label={isExpanded ? '收起分 P' : '展开分 P'}
+                          aria-expanded={isExpanded}
+                        >
+                          <ChevronDown
+                            className={cn(
+                              'h-4 w-4 transition-transform',
+                              isExpanded && 'rotate-180',
+                            )}
+                          />
+                        </Button>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removeItem(trackId);
+                        }}
+                        aria-label="移除"
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    {isExpanded && video?.pages && (
+                      <PartList
+                        pages={video.pages}
+                        activePage={isCurrent ? playingPage : 0}
+                        variant="inline"
+                        onSelect={(page) => {
+                          if (!isCurrent) handlePlayAt(trackId);
+                          switchToPage?.(page);
+                        }}
+                      />
+                    )}
                   </div>
                 );
               })}

--- a/packages/web/src/components/player/s-player.tsx
+++ b/packages/web/src/components/player/s-player.tsx
@@ -18,6 +18,8 @@ import {
 } from 'lucide-react';
 import {
   usePlayerProfileStore,
+  usePlayingListStore,
+  isExplicitPageTrackId,
   urlPrefixFixed,
   formatPlayTime,
   getPlatformBridge,
@@ -52,11 +54,16 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
   const player = useMusicPlayer();
   const volume = usePlayerProfileStore((s) => s.volume);
   const loopMode = usePlayerProfileStore((s) => s.loopMode);
+  const currentTrackId = usePlayingListStore((s) => s.current);
   const openAddToFav = useUIShell((s) => s.openAddToFav);
   const showLyric = useUIShell((s) => s.showLyric);
   const toggleLyric = useUIShell((s) => s.toggleLyric);
 
+  // 显式 :p<n> 条目播放上下文：已锁定 P，不再展示分 P 选择器
+  const isExplicitContext = isExplicitPageTrackId(currentTrackId);
+
   const [showQueue, setShowQueue] = useState(false);
+  const [showPartSelector, setShowPartSelector] = useState(false);
 
   const cur = player.currentVideo;
   const cover = cur?.pic ? urlPrefixFixed(cur.pic) : '';
@@ -225,8 +232,8 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
                   />
                 </PopoverContent>
               </Popover>
-              {cur && (cur.videos ?? 1) > 1 && (
-                <Popover>
+              {cur && (cur.videos ?? 1) > 1 && !isExplicitContext && (
+                <Popover open={showPartSelector} onOpenChange={setShowPartSelector}>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <PopoverTrigger asChild>
@@ -243,7 +250,7 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
                     <TooltipContent>选择分 P</TooltipContent>
                   </Tooltip>
                   <PopoverContent side="top" align="end" sideOffset={10} className="w-auto p-0">
-                    <PartSelector video={cur} />
+                    <PartSelector video={cur} onAfterSubmit={() => setShowPartSelector(false)} />
                   </PopoverContent>
                 </Popover>
               )}

--- a/packages/web/src/components/player/s-player.tsx
+++ b/packages/web/src/components/player/s-player.tsx
@@ -96,8 +96,8 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
        * grid 子级 DOM 顺序：row1 (TopBar) > row2 (NavMenu+main) > row3 (footer)，
        * 同 z auto 时 footer 整体（含 thumb 溢出 6px）渲染在 row2 之上，无需 z-index。
        */}
-      <footer className="relative h-20 border-t bg-background">
-        <div className="absolute -top-[6px] left-0 right-0 px-2">
+      <footer className="relative h-20 border-t bg-background dark:bg-muted">
+        <div className="absolute -top-[6px] left-0 right-0">
           <Slider
             value={[player.progress]}
             max={Math.max(player.duration, 0.01)}

--- a/packages/web/src/components/player/s-player.tsx
+++ b/packages/web/src/components/player/s-player.tsx
@@ -11,9 +11,11 @@ import {
   Volume2,
   VolumeX,
   Music,
+  Captions,
   ListMusic,
   Plus,
   ExternalLink,
+  Expand,
   Layers,
 } from 'lucide-react';
 import {
@@ -35,6 +37,7 @@ import { useMusicPlayer } from '@/hooks/use-music-player';
 import { useUIShell } from '@/stores/ui-shell';
 import { PlayingQueue } from './playing-queue';
 import { PartSelector } from './part-selector';
+import { FloatingLyrics } from './floating-lyrics';
 
 const LOOP_MODE_TIPS: Record<LoopMode, string> = {
   single: '单曲循环',
@@ -58,6 +61,8 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
   const openAddToFav = useUIShell((s) => s.openAddToFav);
   const showLyric = useUIShell((s) => s.showLyric);
   const toggleLyric = useUIShell((s) => s.toggleLyric);
+  const floatingLyricsEnabled = usePlayerProfileStore((s) => s.floatingLyrics.enabled);
+  const toggleFloatingLyrics = usePlayerProfileStore((s) => s.toggleFloatingLyrics);
 
   // 显式 :p<n> 条目播放上下文：已锁定 P，不再展示分 P 选择器
   const isExplicitContext = isExplicitPageTrackId(currentTrackId);
@@ -107,12 +112,29 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
           {/* 左：封面 + 信息 */}
           <div className="flex min-w-0 items-center gap-3">
             {cover ? (
-              <img
-                src={cover}
-                alt=""
-                className="h-12 w-12 cursor-pointer rounded object-cover"
+              <div
+                className="group relative h-12 w-12 shrink-0"
                 onClick={() => cur && !showLyric && toggleLyric()}
-              />
+                role={cur && !showLyric ? 'button' : undefined}
+                aria-label={cur && !showLyric ? '展开全屏歌词' : undefined}
+              >
+                <img
+                  src={cover}
+                  alt=""
+                  className={cn(
+                    'block h-12 w-12 rounded object-cover',
+                    cur && !showLyric && 'cursor-pointer',
+                  )}
+                />
+                {cur && !showLyric && (
+                  <div
+                    className="pointer-events-none absolute inset-0 flex items-center justify-center rounded bg-black/50 opacity-0 transition-opacity group-hover:opacity-100"
+                    aria-hidden
+                  >
+                    <Expand className="h-5 w-5 text-white" />
+                  </div>
+                )}
+              </div>
             ) : (
               <div className="flex h-12 w-12 items-center justify-center rounded bg-muted">
                 <Music className="h-5 w-5 text-muted-foreground" />
@@ -274,13 +296,16 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={toggleLyric}
-                        className={cn(CTRL_BTN_TEXT, showLyric && 'bg-accent')}
+                        onClick={toggleFloatingLyrics}
+                        className={cn(CTRL_BTN_TEXT, floatingLyricsEnabled && 'bg-accent')}
+                        aria-label="悬浮歌词"
                       >
-                        <Music className="h-5 w-5" />
+                        <Captions className="h-5 w-5" />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>{showLyric ? '关闭歌词' : '显示歌词'}</TooltipContent>
+                    <TooltipContent>
+                      {floatingLyricsEnabled ? '关闭悬浮歌词' : '显示悬浮歌词'}
+                    </TooltipContent>
                   </Tooltip>
                 </>
               )}
@@ -301,12 +326,11 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
           </TooltipProvider>
         </div>
 
-        {/* 当前歌词条（无视图时显示在播放器内） */}
-        {!showLyric && player.currentLyricLine && (
-          <p className="pointer-events-none absolute inset-x-0 -top-7 mx-auto w-fit max-w-[60%] truncate rounded bg-background/80 px-3 py-1 text-center text-xs text-primary">
-            {player.currentLyricLine}
-          </p>
-        )}
+        {/* 悬浮歌词：受 floatingLyrics.enabled + 全屏歌词页状态 + 当前歌词条件门控 */}
+        <FloatingLyrics
+          line={player.currentLyricLine ?? ''}
+          visible={!showLyric && floatingLyricsEnabled && !!cur && !!player.currentLyricLine}
+        />
       </footer>
 
       <PlayingQueue open={showQueue} onOpenChange={setShowQueue} />

--- a/packages/web/src/components/player/s-player.tsx
+++ b/packages/web/src/components/player/s-player.tsx
@@ -14,6 +14,7 @@ import {
   ListMusic,
   Plus,
   ExternalLink,
+  Layers,
 } from 'lucide-react';
 import {
   usePlayerProfileStore,
@@ -31,6 +32,7 @@ import { Marquee } from '@/components/marquee';
 import { useMusicPlayer } from '@/hooks/use-music-player';
 import { useUIShell } from '@/stores/ui-shell';
 import { PlayingQueue } from './playing-queue';
+import { PartSelector } from './part-selector';
 
 const LOOP_MODE_TIPS: Record<LoopMode, string> = {
   single: '单曲循环',
@@ -223,6 +225,28 @@ export function SPlayer({ onAddToFav }: SPlayerProps = {}) {
                   />
                 </PopoverContent>
               </Popover>
+              {cur && (cur.videos ?? 1) > 1 && (
+                <Popover>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className={CTRL_BTN_TEXT}
+                          aria-label="选择分 P"
+                        >
+                          <Layers className="h-5 w-5" />
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>选择分 P</TooltipContent>
+                  </Tooltip>
+                  <PopoverContent side="top" align="end" sideOffset={10} className="w-auto p-0">
+                    <PartSelector video={cur} />
+                  </PopoverContent>
+                </Popover>
+              )}
               {cur && (
                 <>
                   <Tooltip>

--- a/packages/web/src/components/ui/slider.tsx
+++ b/packages/web/src/components/ui/slider.tsx
@@ -18,15 +18,15 @@ const Slider = React.forwardRef<
   >
     <SliderPrimitive.Track
       className={cn(
-        'relative grow overflow-hidden rounded-full bg-secondary',
+        // Track 用 foreground 的半透明派生：light 下是低透深色（更深 / 更可辨）；
+        // dark 下是低透浅色（更亮 / 更可辨）。比原 bg-secondary 对比度更高，
+        // 适配 footer / 设置页等浅底 + 暗底两种场景
+        'relative grow overflow-hidden rounded-full bg-foreground/8',
         orientation === 'horizontal' ? 'h-1.5 w-full' : 'h-full w-1.5',
       )}
     >
       <SliderPrimitive.Range
-        className={cn(
-          'absolute bg-primary',
-          orientation === 'horizontal' ? 'h-full' : 'w-full',
-        )}
+        className={cn('absolute bg-primary', orientation === 'horizontal' ? 'h-full' : 'w-full')}
       />
     </SliderPrimitive.Track>
     <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />

--- a/packages/web/src/components/ui/slider.tsx
+++ b/packages/web/src/components/ui/slider.tsx
@@ -10,7 +10,7 @@ const Slider = React.forwardRef<
     ref={ref}
     orientation={orientation}
     className={cn(
-      'relative flex touch-none select-none items-center',
+      'relative flex touch-none select-none items-center bg-background border-t-[1px] border-t-foreground/32',
       orientation === 'horizontal' ? 'w-full' : 'h-full flex-col',
       className,
     )}
@@ -21,7 +21,7 @@ const Slider = React.forwardRef<
         // Track 用 foreground 的半透明派生：light 下是低透深色（更深 / 更可辨）；
         // dark 下是低透浅色（更亮 / 更可辨）。比原 bg-secondary 对比度更高，
         // 适配 footer / 设置页等浅底 + 暗底两种场景
-        'relative grow overflow-hidden rounded-full bg-foreground/8',
+        'relative grow overflow-hidden rounded-full bg-foreground opacity-5',
         orientation === 'horizontal' ? 'h-1.5 w-full' : 'h-full w-1.5',
       )}
     >

--- a/packages/web/src/components/video-item.test.tsx
+++ b/packages/web/src/components/video-item.test.tsx
@@ -10,6 +10,13 @@ import {
 import { useUIShell } from '@/stores/ui-shell';
 import { VideoItem } from './video-item';
 
+function resetUIShell() {
+  useUIShell.setState({
+    pagesPickerOpen: false,
+    pagesPickerVideo: null,
+  });
+}
+
 const SAMPLE: BilibiliVideo = {
   aid: 1,
   bvid: 'BV1Test00001',
@@ -229,15 +236,14 @@ describe('VideoItem: 多 P 投稿操作菜单（D3）', () => {
     expect(screen.getByText(/记住默认 P/)).toBeInTheDocument();
   });
 
-  it('sub menu 展开后渲染所有 P 与时长', async () => {
+  it('点击"选择分 P 添加到歌单"打开 PagesPickerDialog（仅写 store flag）', async () => {
     const user = userEvent.setup();
+    resetUIShell();
     render(<VideoItem video={MULTI} />);
     await user.click(screen.getByRole('button', { name: '更多操作' }));
-    await user.hover(screen.getByText('选择分 P 添加到歌单'));
-    // sub menu 中应能找到 P1/P2/P3 三项标题
-    expect(await screen.findByText('Intro')).toBeInTheDocument();
-    expect(screen.getByText('Verse')).toBeInTheDocument();
-    expect(screen.getByText('Outro')).toBeInTheDocument();
+    await user.click(screen.getByText('选择分 P 添加到歌单'));
+    expect(useUIShell.getState().pagesPickerOpen).toBe(true);
+    expect(useUIShell.getState().pagesPickerVideo?.bvid).toBe(MULTI.bvid);
   });
 
   it('已有默认 P 时，标题显示"当前 P{n}"且 sub menu 列出"清除"项', async () => {

--- a/packages/web/src/components/video-item.test.tsx
+++ b/packages/web/src/components/video-item.test.tsx
@@ -1,5 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { usePlayingListStore, useUIStore, type BilibiliVideo } from '@shuoshuo-player/shared';
+import {
+  usePlayingListStore,
+  useUIStore,
+  useFavoritesStore,
+  type BilibiliVideo,
+} from '@shuoshuo-player/shared';
 import { VideoItem } from './video-item';
 
 const SAMPLE: BilibiliVideo = {
@@ -26,6 +31,7 @@ function reset() {
     playNext: false,
   });
   useUIStore.setState({ notices: [] });
+  useFavoritesStore.setState({ entries: {} });
 }
 
 describe('VideoItem', () => {
@@ -98,10 +104,44 @@ describe('VideoItem', () => {
     render(<VideoItem video={SAMPLE} />);
     const likeBtn = screen.getByRole('button', { name: '收藏' });
     fireEvent.click(likeBtn);
-    // 收藏功能未实装，不应触发播放
+    // 收藏功能不应触发播放
     const state = usePlayingListStore.getState();
     expect(state.bvIds).toEqual([]);
     expect(state.current).toBe('');
+  });
+
+  it('点击收藏按钮：未收藏 → 写入 useFavoritesStore.entries[bvid]', () => {
+    render(<VideoItem video={SAMPLE} />);
+    fireEvent.click(screen.getByRole('button', { name: '收藏' }));
+    const entries = useFavoritesStore.getState().entries;
+    expect('BV1Test00001' in entries).toBe(true);
+    expect(typeof entries['BV1Test00001']).toBe('number');
+  });
+
+  it('点击收藏按钮：已收藏 → 移除', () => {
+    useFavoritesStore.setState({ entries: { BV1Test00001: 100 } });
+    render(<VideoItem video={SAMPLE} />);
+    fireEvent.click(screen.getByRole('button', { name: '收藏' }));
+    expect('BV1Test00001' in useFavoritesStore.getState().entries).toBe(false);
+  });
+
+  it('已收藏时 Star 图标含 fill-current 与 text-yellow-500 样式类', () => {
+    useFavoritesStore.setState({ entries: { BV1Test00001: 100 } });
+    const { container } = render(<VideoItem video={SAMPLE} />);
+    const likeBtn = screen.getByRole('button', { name: '收藏' });
+    const svg = likeBtn.querySelector('svg');
+    expect(svg?.getAttribute('class')).toMatch(/fill-current/);
+    expect(svg?.getAttribute('class')).toMatch(/text-yellow-500/);
+    // 未收藏的 SAMPLE2 不应该带 fill-current
+    void container;
+  });
+
+  it('未收藏时 Star 图标不含 fill-current', () => {
+    const { container } = render(<VideoItem video={SAMPLE} />);
+    const likeBtn = screen.getByRole('button', { name: '收藏' });
+    const svg = likeBtn.querySelector('svg');
+    expect(svg?.getAttribute('class')).not.toMatch(/fill-current/);
+    void container;
   });
 
   it('fromSearch=true 时主按钮调用 onAddToFav 而非播放', () => {

--- a/packages/web/src/components/video-item.test.tsx
+++ b/packages/web/src/components/video-item.test.tsx
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   usePlayingListStore,
   useUIStore,
   useFavoritesStore,
+  useVideoPagePrefStore,
   type BilibiliVideo,
 } from '@shuoshuo-player/shared';
+import { useUIShell } from '@/stores/ui-shell';
 import { VideoItem } from './video-item';
 
 const SAMPLE: BilibiliVideo = {
@@ -26,7 +29,7 @@ const SAMPLE: BilibiliVideo = {
 function reset() {
   usePlayingListStore.setState({
     favId: '',
-    bvIds: [],
+    trackIds: [],
     current: '',
     playNext: false,
   });
@@ -75,7 +78,7 @@ describe('VideoItem', () => {
     fireEvent.doubleClick(root);
 
     const state = usePlayingListStore.getState();
-    expect(state.bvIds).toContain('BV1Test00001');
+    expect(state.trackIds).toContain('BV1Test00001');
     expect(state.current).toBe('BV1Test00001');
     expect(state.playNext).toBe(true);
   });
@@ -87,7 +90,7 @@ describe('VideoItem', () => {
     fireEvent.click(cover);
 
     const state = usePlayingListStore.getState();
-    expect(state.bvIds).toContain('BV1Test00001');
+    expect(state.trackIds).toContain('BV1Test00001');
     expect(state.playNext).toBe(true);
   });
 
@@ -96,7 +99,7 @@ describe('VideoItem', () => {
     fireEvent.doubleClick(container.firstChild as HTMLElement);
 
     const state = usePlayingListStore.getState();
-    expect(state.bvIds).toEqual(['BV1Test00001']);
+    expect(state.trackIds).toEqual(['BV1Test00001']);
     expect(state.playNext).toBe(true);
   });
 
@@ -106,7 +109,7 @@ describe('VideoItem', () => {
     fireEvent.click(likeBtn);
     // 收藏功能不应触发播放
     const state = usePlayingListStore.getState();
-    expect(state.bvIds).toEqual([]);
+    expect(state.trackIds).toEqual([]);
     expect(state.current).toBe('');
   });
 
@@ -155,7 +158,7 @@ describe('VideoItem', () => {
     const { container } = render(<VideoItem video={SAMPLE} fromSearch onAddToFav={vi.fn()} />);
     fireEvent.doubleClick(container.firstChild as HTMLElement);
     const state = usePlayingListStore.getState();
-    expect(state.bvIds).toEqual([]);
+    expect(state.trackIds).toEqual([]);
   });
 
   it('selectMode 下双击不触发播放、封面无 role=button', () => {
@@ -164,7 +167,7 @@ describe('VideoItem', () => {
       <VideoItem video={SAMPLE} selectMode onToggleSelect={onToggleSelect} />,
     );
     fireEvent.doubleClick(container.firstChild as HTMLElement);
-    expect(usePlayingListStore.getState().bvIds).toEqual([]);
+    expect(usePlayingListStore.getState().trackIds).toEqual([]);
     expect(screen.queryByRole('button', { name: '播放' })).toBeNull();
   });
 
@@ -185,5 +188,85 @@ describe('VideoItem', () => {
     render(<VideoItem video={SAMPLE} fullCreateTime />);
     // 完整日期格式 YYYY 年 MM 月 DD 日 HH:mm
     expect(screen.getByText(/年.*月.*日/)).toBeInTheDocument();
+  });
+});
+
+describe('VideoItem: 多 P 投稿操作菜单（D3）', () => {
+  const MULTI: BilibiliVideo = {
+    ...SAMPLE,
+    bvid: 'BV1Multi00001',
+    videos: 3,
+    pages: [
+      { cid: 100, page: 1, part: 'Intro', duration: 60 },
+      { cid: 101, page: 2, part: 'Verse', duration: 90 },
+      { cid: 102, page: 3, part: 'Outro', duration: 30 },
+    ],
+  };
+
+  beforeEach(() => {
+    reset();
+    useVideoPagePrefStore.setState({ defaultPage: {} });
+    useUIShell.setState({
+      addToFavOpen: false,
+      addToFavBvids: [],
+      addToFavExcludeId: null,
+      addToFavFromSearch: false,
+    });
+  });
+
+  it('单 P 投稿打开菜单后不渲染"选择分 P 添加到歌单"sub menu', async () => {
+    const user = userEvent.setup();
+    render(<VideoItem video={SAMPLE} />);
+    await user.click(screen.getByRole('button', { name: '更多操作' }));
+    expect(screen.queryByText('选择分 P 添加到歌单')).not.toBeInTheDocument();
+  });
+
+  it('多 P 投稿菜单含"选择分 P 添加到歌单"与"记住默认 P"', async () => {
+    const user = userEvent.setup();
+    render(<VideoItem video={MULTI} />);
+    await user.click(screen.getByRole('button', { name: '更多操作' }));
+    expect(screen.getByText('选择分 P 添加到歌单')).toBeInTheDocument();
+    expect(screen.getByText(/记住默认 P/)).toBeInTheDocument();
+  });
+
+  it('sub menu 展开后渲染所有 P 与时长', async () => {
+    const user = userEvent.setup();
+    render(<VideoItem video={MULTI} />);
+    await user.click(screen.getByRole('button', { name: '更多操作' }));
+    await user.hover(screen.getByText('选择分 P 添加到歌单'));
+    // sub menu 中应能找到 P1/P2/P3 三项标题
+    expect(await screen.findByText('Intro')).toBeInTheDocument();
+    expect(screen.getByText('Verse')).toBeInTheDocument();
+    expect(screen.getByText('Outro')).toBeInTheDocument();
+  });
+
+  it('已有默认 P 时，标题显示"当前 P{n}"且 sub menu 列出"清除"项', async () => {
+    const user = userEvent.setup();
+    useVideoPagePrefStore.setState({ defaultPage: { BV1Multi00001: 2 } });
+    render(<VideoItem video={MULTI} />);
+    await user.click(screen.getByRole('button', { name: '更多操作' }));
+    expect(screen.getByText(/记住默认 P（当前 P2）/)).toBeInTheDocument();
+    await user.hover(screen.getByText(/记住默认 P/));
+    expect(await screen.findByText('清除默认 P 设置')).toBeInTheDocument();
+  });
+
+  it('无默认 P 时菜单标题不带括号', async () => {
+    const user = userEvent.setup();
+    render(<VideoItem video={MULTI} />);
+    await user.click(screen.getByRole('button', { name: '更多操作' }));
+    // 标题文案恰好是"记住默认 P"（不带括号）
+    const trigger = screen.getByText('记住默认 P');
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('标题左侧渲染 "{N}P" 总数 Badge（仅多 P 视频）', () => {
+    render(<VideoItem video={MULTI} />);
+    const badge = screen.getByLabelText('共 3 分 P');
+    expect(badge).toHaveTextContent('3P');
+  });
+
+  it('单 P 视频不渲染标题左侧 Badge', () => {
+    render(<VideoItem video={SAMPLE} />);
+    expect(screen.queryByLabelText(/共 \d+ 分 P/)).toBeNull();
   });
 });

--- a/packages/web/src/components/video-item.test.tsx
+++ b/packages/web/src/components/video-item.test.tsx
@@ -63,11 +63,10 @@ describe('VideoItem', () => {
     expect(root.className).toMatch(/bg-accent/);
   });
 
-  it('点击立即播放按钮（无 favId）→ setPlaylist + playNext=true', () => {
-    render(<VideoItem video={SAMPLE} />);
-    // 第一个按钮是 PlayCircle ghost icon button（无 aria-label，靠位置识别）
-    const buttons = screen.getAllByRole('button');
-    fireEvent.click(buttons[0]);
+  it('双击行（无 favId）→ setPlaylist + playNext=true', () => {
+    const { container } = render(<VideoItem video={SAMPLE} />);
+    const root = container.firstChild as HTMLElement;
+    fireEvent.doubleClick(root);
 
     const state = usePlayingListStore.getState();
     expect(state.bvIds).toContain('BV1Test00001');
@@ -75,14 +74,34 @@ describe('VideoItem', () => {
     expect(state.playNext).toBe(true);
   });
 
-  it('favId 存在时立即播放走 addSingle 而非 setPlaylist', () => {
-    render(<VideoItem video={SAMPLE} favId="fav-1" />);
-    const buttons = screen.getAllByRole('button');
-    fireEvent.click(buttons[0]);
+  it('点击封面 → 触发播放（与右侧按钮原行为一致）', () => {
+    render(<VideoItem video={SAMPLE} />);
+    // 封面 div 设置了 role="button" + aria-label="播放"
+    const cover = screen.getByRole('button', { name: '播放' });
+    fireEvent.click(cover);
+
+    const state = usePlayingListStore.getState();
+    expect(state.bvIds).toContain('BV1Test00001');
+    expect(state.playNext).toBe(true);
+  });
+
+  it('favId 存在时双击走 addSingle 而非 setPlaylist', () => {
+    const { container } = render(<VideoItem video={SAMPLE} favId="fav-1" />);
+    fireEvent.doubleClick(container.firstChild as HTMLElement);
 
     const state = usePlayingListStore.getState();
     expect(state.bvIds).toEqual(['BV1Test00001']);
     expect(state.playNext).toBe(true);
+  });
+
+  it('右侧按钮在非搜索模式下渲染为"收藏"（aria-label=收藏），点击不触发播放', () => {
+    render(<VideoItem video={SAMPLE} />);
+    const likeBtn = screen.getByRole('button', { name: '收藏' });
+    fireEvent.click(likeBtn);
+    // 收藏功能未实装，不应触发播放
+    const state = usePlayingListStore.getState();
+    expect(state.bvIds).toEqual([]);
+    expect(state.current).toBe('');
   });
 
   it('fromSearch=true 时主按钮调用 onAddToFav 而非播放', () => {
@@ -90,6 +109,23 @@ describe('VideoItem', () => {
     render(<VideoItem video={SAMPLE} fromSearch onAddToFav={onAddToFav} />);
     fireEvent.click(screen.getAllByRole('button')[0]); // 第一个 ghost 按钮（添加到歌单）
     expect(onAddToFav).toHaveBeenCalledWith(SAMPLE, true);
+  });
+
+  it('fromSearch=true 时双击行不触发播放（避免与添加到歌单语义冲突）', () => {
+    const { container } = render(<VideoItem video={SAMPLE} fromSearch onAddToFav={vi.fn()} />);
+    fireEvent.doubleClick(container.firstChild as HTMLElement);
+    const state = usePlayingListStore.getState();
+    expect(state.bvIds).toEqual([]);
+  });
+
+  it('selectMode 下双击不触发播放、封面无 role=button', () => {
+    const onToggleSelect = vi.fn();
+    const { container } = render(
+      <VideoItem video={SAMPLE} selectMode onToggleSelect={onToggleSelect} />,
+    );
+    fireEvent.doubleClick(container.firstChild as HTMLElement);
+    expect(usePlayingListStore.getState().bvIds).toEqual([]);
+    expect(screen.queryByRole('button', { name: '播放' })).toBeNull();
   });
 
   it('htmlTitle=true 时 dangerouslySetInnerHTML 渲染 em 高亮', () => {

--- a/packages/web/src/components/video-item.tsx
+++ b/packages/web/src/components/video-item.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, memo, useCallback, useState } from 'react';
+import { type CSSProperties, type MouseEvent, memo, useCallback, useState } from 'react';
 import dayjs from 'dayjs';
 import {
   Play,
@@ -10,6 +10,7 @@ import {
   ExternalLink,
   Trash2,
   User,
+  Heart,
 } from 'lucide-react';
 import {
   usePlayingListStore,
@@ -104,6 +105,28 @@ function VideoItemImpl({
     onAddToFav?.(video, fromSearch);
   }, [onAddToFav, video, fromSearch]);
 
+  // 收藏功能占位，具体行为待后续讨论后实装
+  const handleToggleLike = useCallback(() => {
+    /* TODO: 收藏功能待实现 */
+  }, []);
+
+  // 封面/行可直接触发播放：仅在非批量选择、非搜索结果场景启用
+  const canPlayDirect = !selectMode && !fromSearch;
+
+  const handleCoverClick = useCallback(
+    (e: MouseEvent) => {
+      if (!canPlayDirect) return;
+      e.stopPropagation();
+      handlePlayClick();
+    },
+    [canPlayDirect, handlePlayClick],
+  );
+
+  const handleRowDoubleClick = useCallback(() => {
+    if (!canPlayDirect) return;
+    handlePlayClick();
+  }, [canPlayDirect, handlePlayClick]);
+
   const handleOpenBilibili = useCallback(() => {
     void getPlatformBridge().shell.openExternal(`https://www.bilibili.com/video/${video.bvid}`);
   }, [video.bvid]);
@@ -122,10 +145,12 @@ function VideoItemImpl({
     <div
       style={style}
       onClick={selectMode ? handleRowClick : undefined}
+      onDoubleClick={canPlayDirect ? handleRowDoubleClick : undefined}
       className={cn(
-        'flex items-center gap-3 rounded-md px-3 py-2 transition-colors',
+        'group/row flex items-center gap-3 rounded-md px-3 py-2 transition-colors',
         !selectMode && 'hover:bg-accent/50',
         !selectMode && isPlaying && 'bg-accent',
+        canPlayDirect && 'select-none',
         selectMode && 'cursor-pointer hover:bg-accent/50',
         selectMode && selected && 'border border-primary/40 bg-primary/10',
         selectMode && !selected && 'border border-transparent',
@@ -141,7 +166,15 @@ function VideoItemImpl({
           />
         </div>
       )}
-      <div className="relative h-12 w-20 shrink-0 overflow-hidden rounded bg-muted">
+      <div
+        onClick={canPlayDirect ? handleCoverClick : undefined}
+        role={canPlayDirect ? 'button' : undefined}
+        aria-label={canPlayDirect ? '播放' : undefined}
+        className={cn(
+          'relative h-12 w-20 shrink-0 overflow-hidden rounded bg-muted',
+          canPlayDirect && 'cursor-pointer',
+        )}
+      >
         {!imgError && video.pic ? (
           <img
             src={bilibiliThumbUrl(video.pic, 200, 125)}
@@ -155,10 +188,16 @@ function VideoItemImpl({
             <PlayCircle className="h-6 w-6" />
           </div>
         )}
-        {isPlaying && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+        {isPlaying ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/50 dark:bg-black/60">
             <PlayCircle className="h-5 w-5 text-white" />
           </div>
+        ) : (
+          canPlayDirect && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 dark:bg-black/60">
+              <PlayCircle className="h-5 w-5 text-white" />
+            </div>
+          )
         )}
       </div>
 
@@ -214,11 +253,11 @@ function VideoItemImpl({
             ) : (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button variant="ghost" size="icon" onClick={handlePlayClick}>
-                    <PlayCircle className="h-4 w-4" />
+                  <Button variant="ghost" size="icon" onClick={handleToggleLike} aria-label="收藏">
+                    <Heart className="h-4 w-4" />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>立即播放</TooltipContent>
+                <TooltipContent>收藏</TooltipContent>
               </Tooltip>
             )}
 

--- a/packages/web/src/components/video-item.tsx
+++ b/packages/web/src/components/video-item.tsx
@@ -10,11 +10,12 @@ import {
   ExternalLink,
   Trash2,
   User,
-  Heart,
+  Star,
 } from 'lucide-react';
 import {
   usePlayingListStore,
   useUIStore,
+  useFavoritesStore,
   formatNumber10K,
   bilibiliThumbUrl,
   getPlatformBridge,
@@ -83,6 +84,9 @@ function VideoItemImpl({
   const setPlaylist = usePlayingListStore((s) => s.setPlaylist);
   const addSingle = usePlayingListStore((s) => s.addSingle);
   const sendNotice = useUIStore((s) => s.sendNotice);
+  // selector 只订阅当前 bvid 的存在性，避免其他收藏变化导致整列重渲染
+  const isFavored = useFavoritesStore((s) => video.bvid in s.entries);
+  const toggleFavorite = useFavoritesStore((s) => s.toggle);
   const [imgError, setImgError] = useState(false);
 
   const isPlaying = currentBvId === video.bvid;
@@ -105,10 +109,14 @@ function VideoItemImpl({
     onAddToFav?.(video, fromSearch);
   }, [onAddToFav, video, fromSearch]);
 
-  // 收藏功能占位，具体行为待后续讨论后实装
   const handleToggleLike = useCallback(() => {
-    /* TODO: 收藏功能待实现 */
-  }, []);
+    const nextFavored = toggleFavorite(video.bvid);
+    sendNotice({
+      type: NoticeType.SUCCESS,
+      message: nextFavored ? '已添加到我的收藏' : '已从我的收藏移除',
+      duration: 2000,
+    });
+  }, [toggleFavorite, sendNotice, video.bvid]);
 
   // 封面/行可直接触发播放：仅在非批量选择、非搜索结果场景启用
   const canPlayDirect = !selectMode && !fromSearch;
@@ -254,10 +262,10 @@ function VideoItemImpl({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button variant="ghost" size="icon" onClick={handleToggleLike} aria-label="收藏">
-                    <Heart className="h-4 w-4" />
+                    <Star className={cn('h-4 w-4', isFavored && 'fill-current text-yellow-500')} />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent>收藏</TooltipContent>
+                <TooltipContent>{isFavored ? '取消收藏' : '收藏'}</TooltipContent>
               </Tooltip>
             )}
 

--- a/packages/web/src/components/video-item.tsx
+++ b/packages/web/src/components/video-item.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type MouseEvent, memo, useCallback, useState } from 'react';
+import { type CSSProperties, type MouseEvent, memo, useCallback, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import {
   Play,
@@ -11,12 +11,17 @@ import {
   Trash2,
   User,
   Star,
+  Layers,
+  Pin,
+  PinOff,
 } from 'lucide-react';
 import {
   usePlayingListStore,
   useUIStore,
   useFavoritesStore,
+  useVideoPagePrefStore,
   formatNumber10K,
+  buildTrackId,
   bilibiliThumbUrl,
   getPlatformBridge,
   NoticeType,
@@ -26,17 +31,27 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import { PartBadge } from './part-badge';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { useUIShell } from '@/stores/ui-shell';
 
 export interface VideoItemProps {
   video: BilibiliVideo;
+  /**
+   * 该条目的显式 P（来自 TrackId 的 :p<n> 部分）；
+   * undefined / 缺省视为纯 bvid 条目，按 video-page-pref 偏好播放。
+   */
+  explicitPage?: number;
   /** 所在歌单 ID，决定播放时是否加载整张歌单 */
   favId?: string;
   showAuthor?: boolean;
@@ -64,6 +79,7 @@ export interface VideoItemProps {
 
 function VideoItemImpl({
   video,
+  explicitPage,
   favId,
   showAuthor = false,
   fullCreateTime = false,
@@ -87,7 +103,43 @@ function VideoItemImpl({
   // selector 只订阅当前 bvid 的存在性，避免其他收藏变化导致整列重渲染
   const isFavored = useFavoritesStore((s) => video.bvid in s.entries);
   const toggleFavorite = useFavoritesStore((s) => s.toggle);
+  // 默认 P 偏好 + 操作（D3）：仅多 P 投稿菜单中显示"记住默认 P"入口
+  const defaultPage = useVideoPagePrefStore((s) => s.defaultPage[video.bvid] ?? 1);
+  const setDefaultPage = useVideoPagePrefStore((s) => s.setDefaultPage);
+  const openAddToFav = useUIShell((s) => s.openAddToFav);
   const [imgError, setImgError] = useState(false);
+
+  const totalP = video.videos ?? 1;
+  const isMultiPart = totalP > 1;
+  /**
+   * 归一化分 P 列表：有 view 元数据时取 pages，缺失时用 1..totalP 占位（仅显示 P 序号）。
+   * 让 DropdownMenuSub 子项渲染统一一份 map，避免双分支重复。
+   */
+  const partItems = useMemo<Array<{ key: string | number; page: number; part?: string }>>(() => {
+    if (video.pages && video.pages.length > 0) {
+      return video.pages.map((p) => ({ key: p.cid, page: p.page, part: p.part }));
+    }
+    return Array.from({ length: totalP }, (_, i) => ({ key: i + 1, page: i + 1 }));
+  }, [video.pages, totalP]);
+
+  const handleAddPageToFav = useCallback(
+    (page: number) => {
+      openAddToFav(buildTrackId(video.bvid, page), { fromSearch });
+    },
+    [openAddToFav, video.bvid, fromSearch],
+  );
+
+  const handlePinDefaultPage = useCallback(
+    (page: number) => {
+      setDefaultPage(video.bvid, page);
+      sendNotice({
+        type: NoticeType.SUCCESS,
+        message: page <= 1 ? '已清除默认 P 设置' : `已设默认 P${page}`,
+        duration: 2000,
+      });
+    },
+    [setDefaultPage, sendNotice, video.bvid],
+  );
 
   const isPlaying = currentBvId === video.bvid;
 
@@ -207,17 +259,32 @@ function VideoItemImpl({
             </div>
           )
         )}
+        {/* 多 P 投稿右下角标：单 P 不渲染（PartBadge 内部判定） */}
+        <div className="pointer-events-none absolute bottom-0.5 right-0.5">
+          <PartBadge video={video} explicitPage={explicitPage} />
+        </div>
       </div>
 
       <div className="min-w-0 flex-1">
-        {htmlTitle ? (
-          <p
-            className="truncate text-sm font-medium [&>em]:not-italic [&>em]:text-primary"
-            dangerouslySetInnerHTML={{ __html: video.title }}
-          />
-        ) : (
-          <p className="truncate text-sm font-medium">{video.title}</p>
-        )}
+        <div className="flex min-w-0 items-center gap-1.5">
+          {isMultiPart && (
+            <Badge
+              variant="outline"
+              className="shrink-0 rounded border-primary/40 bg-primary/15 px-1 py-0 text-[10px] font-medium leading-tight tabular-nums text-primary"
+              aria-label={`共 ${totalP} 分 P`}
+            >
+              {totalP}P
+            </Badge>
+          )}
+          {htmlTitle ? (
+            <p
+              className="min-w-0 flex-1 truncate text-sm font-medium [&>em]:not-italic [&>em]:text-primary"
+              dangerouslySetInnerHTML={{ __html: video.title }}
+            />
+          ) : (
+            <p className="min-w-0 flex-1 truncate text-sm font-medium">{video.title}</p>
+          )}
+        </div>
         <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
           {showAuthor && video.author && (
             <Badge variant="outline" className="gap-1 font-normal">
@@ -271,7 +338,7 @@ function VideoItemImpl({
 
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon">
+                <Button variant="ghost" size="icon" aria-label="更多操作">
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
@@ -287,6 +354,70 @@ function VideoItemImpl({
                     <Plus className="mr-2 h-4 w-4" />
                     添加到歌单
                   </DropdownMenuItem>
+                )}
+                {showAddBtn && isMultiPart && (
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <Layers className="mr-2 h-4 w-4" />
+                      选择分 P 添加到歌单
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="max-h-[60vh] w-64 overflow-y-auto">
+                      {partItems.map((it) => (
+                        <DropdownMenuItem
+                          key={`add-${it.key}`}
+                          onSelect={() => handleAddPageToFav(it.page)}
+                          className="min-w-0"
+                        >
+                          <span className="mr-2 shrink-0 tabular-nums text-muted-foreground">
+                            P{it.page}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">
+                            {it.part || `分P ${it.page}`}
+                          </span>
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                )}
+                {isMultiPart && (
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <Pin className="mr-2 h-4 w-4" />
+                      记住默认 P{defaultPage >= 2 ? `（当前 P${defaultPage}）` : ''}
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="max-h-[60vh] w-64 overflow-y-auto">
+                      {partItems.map((it) => (
+                        <DropdownMenuItem
+                          key={`pin-${it.key}`}
+                          onSelect={() => handlePinDefaultPage(it.page)}
+                          className="min-w-0"
+                        >
+                          <span
+                            className={cn(
+                              'mr-2 shrink-0 tabular-nums',
+                              defaultPage === it.page
+                                ? 'font-semibold text-primary'
+                                : 'text-muted-foreground',
+                            )}
+                          >
+                            P{it.page}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate">
+                            {it.part || `分P ${it.page}`}
+                          </span>
+                        </DropdownMenuItem>
+                      ))}
+                      {defaultPage >= 2 && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onSelect={() => handlePinDefaultPage(1)}>
+                            <PinOff className="mr-2 h-4 w-4" />
+                            清除默认 P 设置
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
                 )}
                 {(showAddBtn || showAddToPlayBtn) && <DropdownMenuSeparator />}
                 <DropdownMenuItem onSelect={handleOpenBilibili}>

--- a/packages/web/src/components/video-item.tsx
+++ b/packages/web/src/components/video-item.tsx
@@ -21,8 +21,8 @@ import {
   useFavoritesStore,
   useVideoPagePrefStore,
   formatNumber10K,
-  buildTrackId,
   bilibiliThumbUrl,
+  buildTrackId,
   getPlatformBridge,
   NoticeType,
   type BilibiliVideo,
@@ -96,24 +96,35 @@ function VideoItemImpl({
   style,
   className,
 }: VideoItemProps) {
-  const currentBvId = usePlayingListStore((s) => s.current);
+  const currentTrackId = usePlayingListStore((s) => s.current);
   const setPlaylist = usePlayingListStore((s) => s.setPlaylist);
   const addSingle = usePlayingListStore((s) => s.addSingle);
   const sendNotice = useUIStore((s) => s.sendNotice);
-  // selector 只订阅当前 bvid 的存在性，避免其他收藏变化导致整列重渲染
-  const isFavored = useFavoritesStore((s) => video.bvid in s.entries);
+  /**
+   * 本行的有效 TrackId：显式 explicitPage 时形如 bvid:p<n>，否则纯 bvid。
+   * 用于 isPlaying 比对、handlePlayClick / addSingle / favorites toggle，
+   * 使同一 bvid 的多个 :p<n> 条目在 UI 上各自独立。
+   */
+  const effectiveTrackId = useMemo(
+    () => buildTrackId(video.bvid, explicitPage),
+    [video.bvid, explicitPage],
+  );
+  // selector 只订阅当前 trackId 的存在性，避免其他收藏变化导致整列重渲染
+  const isFavored = useFavoritesStore((s) => effectiveTrackId in s.entries);
   const toggleFavorite = useFavoritesStore((s) => s.toggle);
   // 默认 P 偏好 + 操作（D3）：仅多 P 投稿菜单中显示"记住默认 P"入口
   const defaultPage = useVideoPagePrefStore((s) => s.defaultPage[video.bvid] ?? 1);
   const setDefaultPage = useVideoPagePrefStore((s) => s.setDefaultPage);
-  const openAddToFav = useUIShell((s) => s.openAddToFav);
+  const openPagesPicker = useUIShell((s) => s.openPagesPicker);
+  const openAddToFavStore = useUIShell((s) => s.openAddToFav);
   const [imgError, setImgError] = useState(false);
 
   const totalP = video.videos ?? 1;
-  const isMultiPart = totalP > 1;
+  // 仅"纯 bvid + 多 P 投稿"才展示分 P 操作入口；显式 :p<n> 条目已锁定 P，隐藏分 P 菜单
+  const isMultiPart = totalP > 1 && explicitPage === undefined;
   /**
-   * 归一化分 P 列表：有 view 元数据时取 pages，缺失时用 1..totalP 占位（仅显示 P 序号）。
-   * 让 DropdownMenuSub 子项渲染统一一份 map，避免双分支重复。
+   * 归一化分 P 列表：view 元数据有 pages 时直接取，缺失时按 totalP 占位生成。
+   * "记住默认 P"sub menu 复用此列表渲染。
    */
   const partItems = useMemo<Array<{ key: string | number; page: number; part?: string }>>(() => {
     if (video.pages && video.pages.length > 0) {
@@ -122,12 +133,9 @@ function VideoItemImpl({
     return Array.from({ length: totalP }, (_, i) => ({ key: i + 1, page: i + 1 }));
   }, [video.pages, totalP]);
 
-  const handleAddPageToFav = useCallback(
-    (page: number) => {
-      openAddToFav(buildTrackId(video.bvid, page), { fromSearch });
-    },
-    [openAddToFav, video.bvid, fromSearch],
-  );
+  const handleOpenPagesPicker = useCallback(() => {
+    openPagesPicker(video);
+  }, [openPagesPicker, video]);
 
   const handlePinDefaultPage = useCallback(
     (page: number) => {
@@ -141,34 +149,40 @@ function VideoItemImpl({
     [setDefaultPage, sendNotice, video.bvid],
   );
 
-  const isPlaying = currentBvId === video.bvid;
+  const isPlaying = currentTrackId === effectiveTrackId;
 
   const handlePlayClick = useCallback(() => {
     if (favId) {
-      // 由调用方决定是否要预先 setPlaylist；这里仅插入并标记 playNow
-      addSingle(video.bvid, true);
+      addSingle(effectiveTrackId, true);
     } else {
-      setPlaylist('', [video.bvid], video.bvid, true);
+      setPlaylist('', [effectiveTrackId], effectiveTrackId, true);
     }
-  }, [addSingle, setPlaylist, favId, video.bvid]);
+  }, [addSingle, setPlaylist, favId, effectiveTrackId]);
 
   const handleAddToPlay = useCallback(() => {
-    addSingle(video.bvid, false);
+    addSingle(effectiveTrackId, false);
     sendNotice({ type: NoticeType.SUCCESS, message: '添加成功', duration: 2000 });
-  }, [addSingle, sendNotice, video.bvid]);
+  }, [addSingle, sendNotice, effectiveTrackId]);
 
   const handleAddToFav = useCallback(() => {
-    onAddToFav?.(video, fromSearch);
-  }, [onAddToFav, video, fromSearch]);
+    // 调用方注入了自定义 onAddToFav（如 discovery 搜索结果页传 fromSearch:true）→ 优先委托；
+    // 未注入时（home / fav-list 等场景）fallback 直接打开 AddToFavDialog，
+    // 用 effectiveTrackId 让显式 :p<n> 条目按精确 P 入歌单。
+    if (onAddToFav) {
+      onAddToFav(video, fromSearch);
+    } else {
+      openAddToFavStore(effectiveTrackId, { fromSearch });
+    }
+  }, [onAddToFav, video, fromSearch, openAddToFavStore, effectiveTrackId]);
 
   const handleToggleLike = useCallback(() => {
-    const nextFavored = toggleFavorite(video.bvid);
+    const nextFavored = toggleFavorite(effectiveTrackId);
     sendNotice({
       type: NoticeType.SUCCESS,
       message: nextFavored ? '已添加到我的收藏' : '已从我的收藏移除',
       duration: 2000,
     });
-  }, [toggleFavorite, sendNotice, video.bvid]);
+  }, [toggleFavorite, sendNotice, effectiveTrackId]);
 
   // 封面/行可直接触发播放：仅在非批量选择、非搜索结果场景启用
   const canPlayDirect = !selectMode && !fromSearch;
@@ -356,28 +370,10 @@ function VideoItemImpl({
                   </DropdownMenuItem>
                 )}
                 {showAddBtn && isMultiPart && (
-                  <DropdownMenuSub>
-                    <DropdownMenuSubTrigger>
-                      <Layers className="mr-2 h-4 w-4" />
-                      选择分 P 添加到歌单
-                    </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="max-h-[60vh] w-64 overflow-y-auto">
-                      {partItems.map((it) => (
-                        <DropdownMenuItem
-                          key={`add-${it.key}`}
-                          onSelect={() => handleAddPageToFav(it.page)}
-                          className="min-w-0"
-                        >
-                          <span className="mr-2 shrink-0 tabular-nums text-muted-foreground">
-                            P{it.page}
-                          </span>
-                          <span className="min-w-0 flex-1 truncate">
-                            {it.part || `分P ${it.page}`}
-                          </span>
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuSub>
+                  <DropdownMenuItem onSelect={handleOpenPagesPicker}>
+                    <Layers className="mr-2 h-4 w-4" />
+                    选择分 P 添加到歌单
+                  </DropdownMenuItem>
                 )}
                 {isMultiPart && (
                   <DropdownMenuSub>

--- a/packages/web/src/hooks/use-music-player.test.tsx
+++ b/packages/web/src/hooks/use-music-player.test.tsx
@@ -17,9 +17,11 @@ import {
   usePlayerProfileStore,
   useLyricsStore,
   useUIStore,
+  useVideoPagePrefStore,
   fetchMusicUrl,
   type BilibiliVideo,
 } from '@shuoshuo-player/shared';
+import { usePlayerRuntimeStore } from '@/stores/player-runtime';
 
 // === Mock fetchMusicUrl 与 LyricApi（避免真实 axios 请求） ===
 vi.mock('@shuoshuo-player/shared', async () => {
@@ -127,7 +129,7 @@ function resetStores() {
   });
   usePlayingListStore.setState({
     favId: 'main',
-    bvIds: [TEST_VIDEO.bvid],
+    trackIds: [TEST_VIDEO.bvid],
     current: TEST_VIDEO.bvid,
     playNext: false,
   });
@@ -397,7 +399,7 @@ describe('H1: useMusicPlayer Howler 回调状态同步', () => {
     });
     usePlayingListStore.setState({
       favId: 'main',
-      bvIds: ['BV1Test00001', 'BV1Test00002'],
+      trackIds: ['BV1Test00001', 'BV1Test00002'],
       current: 'BV1Test00001',
       playNext: false,
     });
@@ -650,7 +652,7 @@ describe('H1: useMusicPlayer 媒体会话 API 接入', () => {
     });
     usePlayingListStore.setState({
       favId: 'main',
-      bvIds: ['BV1Test00001', 'BV1Test00002'],
+      trackIds: ['BV1Test00001', 'BV1Test00002'],
       current: 'BV1Test00001',
       playNext: false,
     });
@@ -726,5 +728,421 @@ describe('H1: useMusicPlayer 媒体会话 API 接入', () => {
     expect(handlers.get('previoustrack')).toBeNull();
     expect(handlers.get('seekto')).toBeNull();
     expect(handlers.get('stop')).toBeNull();
+  });
+});
+
+describe('B5: 多 P 投稿分 P 连播 / 显式 :p<n> 行为', () => {
+  beforeEach(() => {
+    howlerState.HowlMock.mockClear();
+    howlerState.lastCb = {};
+    howlerState.lastInstance = null as never;
+    howlerState.isPlayingMock = false;
+    howlerState.seekValueMock = 0;
+    howlerState.durationMock = 30;
+    resetStores();
+    useVideoPagePrefStore.setState({ defaultPage: {} });
+    vi.mocked(fetchMusicUrl).mockReset();
+    vi.mocked(fetchMusicUrl).mockResolvedValue('https://test.example/audio.m4s');
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const MULTI_VIDEO: BilibiliVideo = {
+    ...TEST_VIDEO,
+    bvid: 'BV1Multi00001',
+    videos: 3,
+    pages: [
+      { cid: 100, page: 1, part: 'P1', duration: 60 },
+      { cid: 101, page: 2, part: 'P2', duration: 90 },
+      { cid: 102, page: 3, part: 'P3', duration: 30 },
+    ],
+  };
+
+  function setupMulti(currentTrackId: string) {
+    useBilibiliVideosStore.setState({
+      ids: [MULTI_VIDEO.bvid, 'BV1Next00001'],
+      entities: {
+        [MULTI_VIDEO.bvid]: MULTI_VIDEO,
+        BV1Next00001: { ...TEST_VIDEO, bvid: 'BV1Next00001', title: 'Next Song' },
+      },
+    });
+    usePlayingListStore.setState({
+      favId: 'main',
+      trackIds: [MULTI_VIDEO.bvid, 'BV1Next00001'],
+      current: currentTrackId,
+      playNext: false,
+    });
+  }
+
+  it('autoPlayNextPage=true + 纯 bvid + 多 P + 未到末尾 → onend 切下一 P（不动 store.current）', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: true,
+    });
+    setupMulti(MULTI_VIDEO.bvid);
+
+    renderHook(() => useMusicPlayer());
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+    expect(vi.mocked(fetchMusicUrl).mock.calls[0]?.[4]).toBe(1);
+
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    // 触发 onend：P1 结束 → 应切到 P2，store.current 不变（仍是纯 bvid）
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+    await waitFor(() =>
+      expect(vi.mocked(fetchMusicUrl).mock.calls.some((c) => c[4] === 2)).toBe(true),
+    );
+    expect(usePlayingListStore.getState().current).toBe(MULTI_VIDEO.bvid);
+  });
+
+  it('autoPlayNextPage=false → 多 P 投稿 onend 也直接切下一首', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: false,
+    });
+    setupMulti(MULTI_VIDEO.bvid);
+
+    renderHook(() => useMusicPlayer());
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+
+    expect(usePlayingListStore.getState().current).toBe('BV1Next00001');
+  });
+
+  it('显式 :p<n> TrackId 即使 autoPlayNextPage=true 也走 next（不连播）', async () => {
+    // 模拟"自定义歌单"场景：trackIds 含显式 :p<n> 条目（与 §2 列表语义边界一致）
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: true,
+    });
+    const explicitTrack = `${MULTI_VIDEO.bvid}:p2`;
+    useBilibiliVideosStore.setState({
+      ids: [MULTI_VIDEO.bvid, 'BV1Next00001'],
+      entities: {
+        [MULTI_VIDEO.bvid]: MULTI_VIDEO,
+        BV1Next00001: { ...TEST_VIDEO, bvid: 'BV1Next00001', title: 'Next Song' },
+      },
+    });
+    usePlayingListStore.setState({
+      favId: 'custom',
+      trackIds: [explicitTrack, 'BV1Next00001'],
+      current: explicitTrack,
+      playNext: false,
+    });
+
+    renderHook(() => useMusicPlayer());
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+    // fetchMusicUrl 起始 P 应为 2（显式）
+    expect(vi.mocked(fetchMusicUrl).mock.calls[0]?.[4]).toBe(2);
+
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+
+    // 显式 :p2 条目 onend 直接走 next() → 队列下一首
+    expect(usePlayingListStore.getState().current).toBe('BV1Next00001');
+  });
+
+  it('autoPlayNextPage=true + 末尾 P → onend 切下一首（不再尝试 P4）', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: true,
+    });
+    setupMulti(MULTI_VIDEO.bvid);
+    // 预置默认 P 为最后一 P
+    useVideoPagePrefStore.setState({ defaultPage: { [MULTI_VIDEO.bvid]: 3 } });
+
+    renderHook(() => useMusicPlayer());
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+    // 起始 P=3（从 defaultPage 读取）
+    expect(vi.mocked(fetchMusicUrl).mock.calls[0]?.[4]).toBe(3);
+
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+
+    // 已经是最后 P → 切到队列下一首
+    expect(usePlayingListStore.getState().current).toBe('BV1Next00001');
+  });
+
+  it('单 P 投稿 autoPlayNextPage=true 也不走分 P 连播', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: true,
+    });
+    useBilibiliVideosStore.setState({
+      ids: [TEST_VIDEO.bvid, 'BV1Next00001'],
+      entities: {
+        [TEST_VIDEO.bvid]: TEST_VIDEO,
+        BV1Next00001: { ...TEST_VIDEO, bvid: 'BV1Next00001', title: 'Next' },
+      },
+    });
+    usePlayingListStore.setState({
+      favId: 'main',
+      trackIds: [TEST_VIDEO.bvid, 'BV1Next00001'],
+      current: TEST_VIDEO.bvid,
+      playNext: false,
+    });
+
+    renderHook(() => useMusicPlayer());
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+
+    expect(usePlayingListStore.getState().current).toBe('BV1Next00001');
+  });
+
+  it('defaultPage 偏好：纯 bvid 起播按 defaultPage 选择初始 P', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: false,
+    });
+    setupMulti(MULTI_VIDEO.bvid);
+    useVideoPagePrefStore.setState({ defaultPage: { [MULTI_VIDEO.bvid]: 2 } });
+
+    renderHook(() => useMusicPlayer());
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+
+    expect(vi.mocked(fetchMusicUrl).mock.calls[0]?.[4]).toBe(2);
+  });
+});
+
+describe('F4: 连续切 P 链 + 用户手动 switchToPage', () => {
+  beforeEach(() => {
+    howlerState.HowlMock.mockClear();
+    howlerState.lastCb = {};
+    howlerState.lastInstance = null as never;
+    howlerState.isPlayingMock = false;
+    howlerState.seekValueMock = 0;
+    howlerState.durationMock = 30;
+    resetStores();
+    useVideoPagePrefStore.setState({ defaultPage: {} });
+    vi.mocked(fetchMusicUrl).mockReset();
+    vi.mocked(fetchMusicUrl).mockResolvedValue('https://test.example/audio.m4s');
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const MULTI: BilibiliVideo = {
+    aid: 1,
+    bvid: 'BV1ChainP00001',
+    created: 0,
+    length: '',
+    pic: '',
+    is_union_video: false,
+    title: 'Chain Multi',
+    sub_title: '',
+    play: 0,
+    comment: 0,
+    author: '',
+    description: '',
+    videos: 3,
+    pages: [
+      { cid: 100, page: 1, part: 'P1', duration: 10 },
+      { cid: 101, page: 2, part: 'P2', duration: 10 },
+      { cid: 102, page: 3, part: 'P3', duration: 10 },
+    ],
+  };
+
+  function setup(currentTrackId: string, nextBv = 'BV1ChainNext') {
+    useBilibiliVideosStore.setState({
+      ids: [MULTI.bvid, nextBv],
+      entities: {
+        [MULTI.bvid]: MULTI,
+        [nextBv]: { ...TEST_VIDEO, bvid: nextBv, title: 'After Chain' },
+      },
+    });
+    usePlayingListStore.setState({
+      favId: 'main',
+      trackIds: [MULTI.bvid, nextBv],
+      current: currentTrackId,
+      playNext: false,
+    });
+  }
+
+  it('autoPlayNextPage=true：onend P1→P2→P3→队列下一首 (3 段链)', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: true,
+    });
+    setup(MULTI.bvid);
+
+    renderHook(() => useMusicPlayer());
+
+    // P1 启动
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(fetchMusicUrl).mock.calls[0]?.[4]).toBe(1);
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    // P1 结束 → P2
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(fetchMusicUrl).mock.calls.at(-1)?.[4]).toBe(2);
+    // store.current 维持纯 bvid 不变
+    expect(usePlayingListStore.getState().current).toBe(MULTI.bvid);
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    // P2 结束 → P3
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(3));
+    expect(vi.mocked(fetchMusicUrl).mock.calls.at(-1)?.[4]).toBe(3);
+    expect(usePlayingListStore.getState().current).toBe(MULTI.bvid);
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    // P3 结束（末尾 P）→ 切到队列下一首
+    act(() => {
+      howlerState.lastCb.onend?.();
+    });
+    expect(usePlayingListStore.getState().current).toBe('BV1ChainNext');
+  });
+
+  it('用户手动 switchToPage(n) → 触发新的 fetchMusicUrl + Howler 重建', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: false,
+    });
+    setup(MULTI.bvid);
+    renderHook(() => useMusicPlayer());
+
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(fetchMusicUrl).mock.calls[0]?.[4]).toBe(1);
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    // 模拟外部组件（PartSelector / PlayingQueue）调 switchToPage(2)
+    const switchToPage = usePlayerRuntimeStore.getState().switchToPage;
+    expect(switchToPage).toBeTypeOf('function');
+    await act(async () => {
+      switchToPage?.(2);
+    });
+
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(fetchMusicUrl).mock.calls.at(-1)?.[4]).toBe(2);
+    // playingPage 状态推送到 runtime store
+    expect(usePlayerRuntimeStore.getState().playingPage).toBe(2);
+    // store.current 不动（用户视角 TrackId 稳定）
+    expect(usePlayingListStore.getState().current).toBe(MULTI.bvid);
+  });
+
+  it('switchToPage 越界值被 clamp 到 [1, totalP]', async () => {
+    usePlayerProfileStore.setState({
+      volume: 0.5,
+      autoPlay: true,
+      loopMode: 'loop',
+      autoPlayNextPage: false,
+    });
+    setup(MULTI.bvid);
+    renderHook(() => useMusicPlayer());
+
+    await act(async () => {
+      usePlayingListStore.setState({ playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalled());
+    act(() => {
+      howlerState.lastCb.onplay?.();
+    });
+
+    // 越界上限：传 99 → clamp 到 3
+    const switchToPage = usePlayerRuntimeStore.getState().switchToPage;
+    await act(async () => {
+      switchToPage?.(99);
+    });
+    expect(usePlayerRuntimeStore.getState().playingPage).toBe(3);
+
+    // 越界下限：传 0 / 负数 → clamp 到 1
+    await act(async () => {
+      switchToPage?.(0);
+    });
+    expect(usePlayerRuntimeStore.getState().playingPage).toBe(1);
+
+    await act(async () => {
+      switchToPage?.(-5);
+    });
+    expect(usePlayerRuntimeStore.getState().playingPage).toBe(1);
   });
 });

--- a/packages/web/src/hooks/use-music-player.test.tsx
+++ b/packages/web/src/hooks/use-music-player.test.tsx
@@ -481,6 +481,101 @@ describe('H1: useMusicPlayer Howler 回调状态同步', () => {
     expect(usePlayingListStore.getState().playNext).toBe(false);
     expect(result.current.isPlaying).toBe(false);
   });
+
+  // === 双音频并发 bug 回归：快速切歌时旧请求 resolve 不应创建孤儿 Howl 自动播放 ===
+  it('快速切歌竞态：旧 fetchMusicUrl 晚到（gen stale）→ 不创建第二个 Howl 实例', async () => {
+    // 第二个视频
+    const VIDEO_B: BilibiliVideo = { ...TEST_VIDEO, bvid: 'BV1Test00002', title: 'Song B' };
+    useBilibiliVideosStore.setState({
+      ids: [TEST_VIDEO.bvid, VIDEO_B.bvid],
+      entities: { [TEST_VIDEO.bvid]: TEST_VIDEO, [VIDEO_B.bvid]: VIDEO_B },
+    });
+
+    // 让第一次 fetchMusicUrl 永不 resolve（模拟慢网络），第二次正常 resolve
+    let resolveA: ((url: string) => void) | null = null;
+    vi.mocked(fetchMusicUrl)
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveA = resolve;
+          }),
+      )
+      .mockImplementationOnce(async () => 'https://test.example/B.m4s');
+
+    renderHook(() => useMusicPlayer());
+
+    // 1) 触发 A 的播放，initHowl 进入 await（fetchMusicUrl A 未 resolve）
+    await act(async () => {
+      usePlayingListStore.setState({ current: TEST_VIDEO.bvid, playNext: true });
+    });
+    // A 尚未创建 Howl，因为 fetchMusicUrl pending
+    expect(howlerState.HowlMock).not.toHaveBeenCalled();
+
+    // 2) 用户快速切到 B：gen++，新 initHowl 进入，B 立即返回 URL → 构造 Howl-B
+    await act(async () => {
+      usePlayingListStore.setState({ current: VIDEO_B.bvid, playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(1));
+    const howlBPlayCount = howlerState.lastInstance!.play.mock.calls.length;
+
+    // 3) 现在 A 的 fetchMusicUrl 终于 resolve → 应被 gen 哨兵拦截，不构造第二个 Howl
+    await act(async () => {
+      resolveA?.('https://test.example/A.m4s');
+      // 让 microtask 排空
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 关键断言：Howl 构造次数仍为 1（只有 B），A 没有产生孤儿实例
+    expect(howlerState.HowlMock).toHaveBeenCalledTimes(1);
+    // B 的 play 次数没变（不会被 A 路径触发额外 play）
+    expect(howlerState.lastInstance!.play.mock.calls.length).toBe(howlBPlayCount);
+  });
+
+  it('快速切歌竞态：旧 Howl 的 onload 触发时（已 stale）不应调 play()', async () => {
+    const VIDEO_B: BilibiliVideo = { ...TEST_VIDEO, bvid: 'BV1Test00002', title: 'Song B' };
+    useBilibiliVideosStore.setState({
+      ids: [TEST_VIDEO.bvid, VIDEO_B.bvid],
+      entities: { [TEST_VIDEO.bvid]: TEST_VIDEO, [VIDEO_B.bvid]: VIDEO_B },
+    });
+
+    // 两次都立即返回 URL，但我们手动控制何时触发 onload
+    vi.mocked(fetchMusicUrl)
+      .mockImplementationOnce(async () => 'https://test.example/A.m4s')
+      .mockImplementationOnce(async () => 'https://test.example/B.m4s');
+
+    renderHook(() => useMusicPlayer());
+
+    // 1) 播放 A，Howl-A 创建（构造时同步 play() 一次），但暂不触发 onload
+    await act(async () => {
+      usePlayingListStore.setState({ current: TEST_VIDEO.bvid, playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(1));
+    const cbA = howlerState.lastCb;
+    const instanceA = howlerState.lastInstance!;
+
+    // 2) 切到 B：Howl-B 创建（gen++）
+    await act(async () => {
+      usePlayingListStore.setState({ current: VIDEO_B.bvid, playNext: true });
+    });
+    await waitFor(() => expect(howlerState.HowlMock).toHaveBeenCalledTimes(2));
+    const instanceB = howlerState.lastInstance!;
+    const playACountBefore = instanceA.play.mock.calls.length;
+    const stopACountBefore = instanceA.stop.mock.calls.length;
+
+    // 3) A 的 onload 现在才触发（旧 Howl 的回调晚到）→ 哨兵应拦截：不调 A.play()，应调 A.stop()/A.unload()
+    act(() => {
+      cbA.onload?.();
+    });
+
+    // A.play() 调用次数没变（onload 内的 if (autoPlay) howl.play() 未执行）
+    expect(instanceA.play.mock.calls.length).toBe(playACountBefore);
+    // 哨兵主动销毁 A
+    expect(instanceA.stop.mock.calls.length).toBeGreaterThan(stopACountBefore);
+    expect(instanceA.unload).toHaveBeenCalled();
+    // B 实例不受影响
+    expect(instanceB).toBe(howlerState.lastInstance);
+  });
 });
 
 describe('H1: useMusicPlayer 媒体会话 API 接入', () => {

--- a/packages/web/src/hooks/use-music-player.ts
+++ b/packages/web/src/hooks/use-music-player.ts
@@ -128,6 +128,9 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
   const initHowlRef = useRef<((video: BilibiliVideo, attempt?: number) => Promise<void>) | null>(
     null,
   );
+  // 并发哨兵：快速切歌时旧的 fetchMusicUrl 仍可能 resolve，凭 gen 比对丢弃所有 stale 路径
+  // （await 后、onload、onloaderror、onplay、onend 等回调都会检查），防止孤儿 Howl 自动播放
+  const initGenRef = useRef(0);
 
   const [isLoading, setIsLoading] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -203,6 +206,10 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
   // 初始化 Howl 实例
   const initHowl = useCallback(
     async (video: BilibiliVideo, attempt: number = 0) => {
+      // 占用一个新 generation，作为本次调用的身份标识
+      // 所有异步回调（await 后、Howl 构造、onload、onloaderror）都对照 gen，stale 路径直接丢弃
+      const gen = ++initGenRef.current;
+
       // 释放旧实例
       if (howlRef.current) {
         howlRef.current.stop();
@@ -258,6 +265,14 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
           url || '<EMPTY>',
         );
       }
+      // Stale 校验（最关键的拦截点）：await 期间用户已切歌，丢弃此次结果
+      // 不调 setIsLoading(false)：新调用已接管 loading 状态，避免视觉跳动
+      if (gen !== initGenRef.current) {
+        if (__DEV_LOG__) {
+          console.debug('[BILI-API] initHowl stale (post-fetch), drop:', video.bvid, 'gen=', gen);
+        }
+        return;
+      }
       if (!url) {
         setIsLoading(false);
         // 解析失败直接停在当前曲目，不再自动跳下一首；toast 已由 onFinalError 发出
@@ -273,11 +288,30 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
         html5: true,
         volume,
         onload: () => {
+          // 该实例属于已过期的初始化（用户已切歌）→ 立即销毁，不调 play()
+          if (gen !== initGenRef.current) {
+            try {
+              howl.stop();
+              howl.unload();
+            } catch {
+              /* 忽略：unload 期间可能抛错，无害 */
+            }
+            return;
+          }
           setIsLoading(false);
           setDuration(howl.duration());
           if (autoPlay) howl.play();
         },
         onloaderror: (id, err) => {
+          // stale：用户已切歌，旧 Howl 的加载错误不应触发降级重试
+          if (gen !== initGenRef.current) {
+            try {
+              howl.unload();
+            } catch {
+              /* 忽略 */
+            }
+            return;
+          }
           // 取 howl 内部 audio element 的 MediaError 详情：err 仅是 howler 抽象数字（4=src not supported），
           // 真实失败原因由浏览器写在 audioEl.error.{code, message}
           let mediaErrInfo: { code: number; message: string } | null = null;
@@ -350,6 +384,16 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
           });
         },
         onplay: () => {
+          // 兜底（onload 已拦截 99% 路径）：stale 实例不应推动 isPlaying / 清 playNext
+          if (gen !== initGenRef.current) {
+            try {
+              howl.stop();
+              howl.unload();
+            } catch {
+              /* 忽略 */
+            }
+            return;
+          }
           setIsPlaying(true);
           setIsPausing(false);
           startRaf();
@@ -360,25 +404,45 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
           }
         },
         onpause: () => {
+          if (gen !== initGenRef.current) return;
           setIsPlaying(false);
           setIsPausing(true);
           stopRaf();
         },
         onstop: () => {
+          if (gen !== initGenRef.current) return;
           setIsPlaying(false);
           setIsPausing(false);
           setProgress(0);
           stopRaf();
         },
         onseek: () => {
+          if (gen !== initGenRef.current) return;
           const cur = howl.seek();
           if (typeof cur === 'number') setProgress(cur);
         },
-        onend: handleEnd,
+        // stale 的 onend 绝不能触发 goNext，否则会越过用户的切歌意图
+        onend: () => {
+          if (gen !== initGenRef.current) return;
+          handleEnd();
+        },
         onplayerror: () => {
+          if (gen !== initGenRef.current) return;
           howl.once('unlock', () => howl.play());
         },
       });
+
+      // 极端 race：构造期间又被切歌（同步路径几乎不可能，但 Howl 构造内部有微任务）
+      // 兜底丢弃，避免装到 howlRef 后又被新实例覆盖造成"双 howl 内存中并存"
+      if (gen !== initGenRef.current) {
+        try {
+          howl.stop();
+          howl.unload();
+        } catch {
+          /* 忽略 */
+        }
+        return;
+      }
       howlRef.current = howl;
       // 立即播放（首次 onplay 触发后清除 playNext）
       howl.play();
@@ -395,7 +459,8 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
   useEffect(() => {
     if (!playNext) return;
     if (!currentVideo) {
-      // 当前曲目被删除，停止并清除信号
+      // 当前曲目被删除：自增 gen 让任何 pending initHowl 进入 stale，避免它继续构造孤儿 Howl
+      initGenRef.current++;
       if (howlRef.current) {
         howlRef.current.stop();
         howlRef.current.unload();
@@ -448,6 +513,8 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
   // 卸载时释放
   useEffect(() => {
     return () => {
+      // 自增 gen：让卸载后才 resolve 的 pending fetchMusicUrl 不再构造 Howl
+      initGenRef.current++;
       stopRaf();
       if (howlRef.current) {
         howlRef.current.stop();

--- a/packages/web/src/hooks/use-music-player.ts
+++ b/packages/web/src/hooks/use-music-player.ts
@@ -7,8 +7,11 @@ import {
   usePlayerProfileStore,
   useLyricsStore,
   useUIStore,
+  useVideoPagePrefStore,
   fetchMusicUrl,
   invalidateMusicUrlCache,
+  parseTrackId,
+  buildTrackId,
   urlPrefixFixed,
   LyricApi,
   NoticeType,
@@ -121,16 +124,18 @@ async function probeAudioUrl(url: string, bvid: string): Promise<void> {
 export function useMusicPlayer(): PlayerState & PlayerControls {
   const howlRef = useRef<Howl | null>(null);
   const rafRef = useRef<number | null>(null);
-  const lastClearedBvRef = useRef<string>('');
+  // 按 TrackId（bvid 或 bvid:p<n>）比对，避免同 bvid 切 P 时不清 playNext
+  const lastClearedTrackRef = useRef<string>('');
   // mediaSession.setPositionState 用 ref 读最新进度，避免高频 setProgress 让 effect 反复重建定时器
   const progressRef = useRef(0);
-  // initHowl 自递归（onloaderror 重试时调用最新版本）通过 ref 解耦，避免 useCallback 循环依赖
-  const initHowlRef = useRef<((video: BilibiliVideo, attempt?: number) => Promise<void>) | null>(
-    null,
-  );
+  // initHowl 自递归（onloaderror 重试时调用最新版本 / handleEnd 分 P 连播调下一 P）通过 ref 解耦
+  const initHowlRef = useRef<
+    ((video: BilibiliVideo, page: number, attempt?: number) => Promise<void>) | null
+  >(null);
   // 并发哨兵：快速切歌时旧的 fetchMusicUrl 仍可能 resolve，凭 gen 比对丢弃所有 stale 路径
-  // （await 后、onload、onloaderror、onplay、onend 等回调都会检查），防止孤儿 Howl 自动播放
   const initGenRef = useRef(0);
+  // 当前实际播放的 P（与 store.current 解耦：分 P 连播时只动 ref 不动 store，避免污染用户视角的 TrackId）
+  const playingPageRef = useRef(1);
 
   const [isLoading, setIsLoading] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -142,12 +147,20 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
   progressRef.current = progress;
 
   const biliMid = useBilibiliUserStore((s) => s.current?.mid);
-  const currentBvId = usePlayingListStore((s) => s.current);
+  const currentTrackId = usePlayingListStore((s) => s.current);
   const playNext = usePlayingListStore((s) => s.playNext);
   const clearPlayNext = usePlayingListStore((s) => s.clearPlayNext);
   const updateCurrentPlaying = usePlayingListStore((s) => s.updateCurrentPlaying);
   const getNextIndex = usePlayingListStore((s) => s.getNextIndex);
   const getPrevIndex = usePlayingListStore((s) => s.getPrevIndex);
+
+  // TrackId 解析：parsed 为 null 视为脏数据，回落到把整个 currentTrackId 当 bvid（兼容历史）
+  const parsedTrack = useMemo(
+    () => (currentTrackId ? parseTrackId(currentTrackId) : null),
+    [currentTrackId],
+  );
+  const currentBvId = parsedTrack?.bvid ?? currentTrackId;
+  const explicitPage = parsedTrack?.page;
 
   const videoEntities = useBilibiliVideosStore((s) => s.entities);
   const currentVideo = currentBvId ? (videoEntities[currentBvId] ?? null) : null;
@@ -155,6 +168,7 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
   const volume = usePlayerProfileStore((s) => s.volume);
   const autoPlay = usePlayerProfileStore((s) => s.autoPlay);
   const loopMode = usePlayerProfileStore((s) => s.loopMode);
+  const autoPlayNextPage = usePlayerProfileStore((s) => s.autoPlayNextPage);
   const setVolumeStore = usePlayerProfileStore((s) => s.setVolume);
   const setLoopMode = usePlayerProfileStore((s) => s.setLoopMode);
 
@@ -200,15 +214,38 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
       howlRef.current.play();
       return;
     }
+
+    // 分 P 连播判定（B5）：满足全部条件才切下一 P，否则原 goNext()
+    // 1. autoPlayNextPage=true（用户在设置中开启了实验性连播）
+    // 2. 当前 TrackId 是纯 bvid（非显式 :p<n>，显式条目永远走 next）
+    // 3. currentVideo 是多 P 投稿（videos > 1）
+    // 4. 当前实际播放 P 未到末尾（playingPage < videos）
+    const totalP = currentVideo?.videos ?? 1;
+    const curP = playingPageRef.current;
+    if (
+      autoPlayNextPage &&
+      explicitPage === undefined &&
+      currentVideo &&
+      totalP > 1 &&
+      curP < totalP
+    ) {
+      void initHowlRef.current?.(currentVideo, curP + 1);
+      return;
+    }
+
     goNext();
-  }, [loopMode, goNext]);
+  }, [loopMode, goNext, autoPlayNextPage, explicitPage, currentVideo]);
 
   // 初始化 Howl 实例
   const initHowl = useCallback(
-    async (video: BilibiliVideo, attempt: number = 0) => {
+    async (video: BilibiliVideo, page: number, attempt: number = 0) => {
       // 占用一个新 generation，作为本次调用的身份标识
       // 所有异步回调（await 后、Howl 构造、onload、onloaderror）都对照 gen，stale 路径直接丢弃
       const gen = ++initGenRef.current;
+      // 同步更新"实际播放的 P"，供 onend 分 P 连播 / mediaSession 等使用
+      playingPageRef.current = page;
+      // 推送到 runtime store，让外部订阅方（如 PlayingQueue / SPlayer P 选择器）看到当前 P
+      usePlayerRuntimeStore.setState({ playingPage: page });
 
       // 释放旧实例
       if (howlRef.current) {
@@ -222,39 +259,50 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
       setIsLoading(true);
 
       // mediaSession 元数据：MediaMetadata 在某些 WebView / jsdom 环境下未提供，做能力探测
-      // 仅 attempt=0 时刷新（重试不需要重置元数据）
+      // 仅 attempt=0 时刷新（重试不需要重置元数据）。多 P 投稿在标题加 P 后缀，便于锁屏识别
       if (
         attempt === 0 &&
         'mediaSession' in navigator &&
         typeof MediaMetadata !== 'undefined' &&
         video.title
       ) {
+        const isMultiPart = (video.videos ?? 1) > 1;
+        const partTitle = isMultiPart ? video.pages?.[page - 1]?.part : undefined;
+        const displayTitle = isMultiPart
+          ? `${video.title}（P${page}${partTitle ? ` - ${partTitle}` : ''}）`
+          : video.title;
         navigator.mediaSession.metadata = new MediaMetadata({
-          title: video.title,
+          title: displayTitle,
           artist: video.author,
           artwork: video.pic ? [{ src: urlPrefixFixed(video.pic) }] : undefined,
         });
       }
 
       // 提取最终错误用于失败后分类 toast；onRetry 期间显示 INFO toast 反馈重试进度
-      const url = await fetchMusicUrl(video.bvid, biliMid, attempt, {
-        onRetry: ({ retryCount, maxRetries }) => {
-          sendNotice({
-            type: NoticeType.INFO,
-            message: `B 站接口暂时不通，正在重试 (${retryCount}/${maxRetries})...`,
-            duration: 2000,
-          });
+      const url = await fetchMusicUrl(
+        video.bvid,
+        biliMid,
+        attempt,
+        {
+          onRetry: ({ retryCount, maxRetries }) => {
+            sendNotice({
+              type: NoticeType.INFO,
+              message: `B 站接口暂时不通，正在重试 (${retryCount}/${maxRetries})...`,
+              duration: 2000,
+            });
+          },
+          onFinalError: (err) => {
+            // 风控已有全局对话框引导用户去主站验证，无需再弹 toast 避免双重提示
+            if (err.kind === 'risk-control') return;
+            sendNotice({
+              type: NoticeType.ERROR,
+              message: buildFetchMusicUrlErrorToast(err),
+              duration: 6000,
+            });
+          },
         },
-        onFinalError: (err) => {
-          // 风控已有全局对话框引导用户去主站验证，无需再弹 toast 避免双重提示
-          if (err.kind === 'risk-control') return;
-          sendNotice({
-            type: NoticeType.ERROR,
-            message: buildFetchMusicUrlErrorToast(err),
-            duration: 6000,
-          });
-        },
-      });
+        page,
+      );
       if (__DEV_LOG__) {
         console.debug(
           '[BILI-API] initHowl got url:',
@@ -370,8 +418,8 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
               message: `音频加载失败，降级重试 (${attempt + 1}/${AUDIO_FALLBACK_MAX_ATTEMPT})`,
               duration: 2000,
             });
-            // 通过 ref 调最新的 initHowl，避免捕获旧版本闭包
-            void initHowlRef.current?.(video, attempt + 1);
+            // 通过 ref 调最新的 initHowl，避免捕获旧版本闭包；保持 page 不变
+            void initHowlRef.current?.(video, page, attempt + 1);
             return;
           }
 
@@ -397,10 +445,12 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
           setIsPlaying(true);
           setIsPausing(false);
           startRaf();
-          // 防止重复清除（同一首歌多次 onplay 触发）
-          if (lastClearedBvRef.current !== video.bvid) {
+          // 防止重复清除（同一 trackId 多次 onplay 触发）
+          // 用 buildTrackId(bvid, page) 比对，确保同 bvid 切 P 时仍能正确清 playNext
+          const trackKey = buildTrackId(video.bvid, page);
+          if (lastClearedTrackRef.current !== trackKey) {
             clearPlayNext();
-            lastClearedBvRef.current = video.bvid;
+            lastClearedTrackRef.current = trackKey;
           }
         },
         onpause: () => {
@@ -455,7 +505,8 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
     initHowlRef.current = initHowl;
   }, [initHowl]);
 
-  // 监听 playNext 信号 + currentVideo 变化
+  // 监听 playNext 信号 + currentTrackId / currentVideo 变化
+  // deps 加 currentTrackId 是为了让"同 bvid 切 P"（例如 BV1 → BV1:p3）也触发 effect 重跑
   useEffect(() => {
     if (!playNext) return;
     if (!currentVideo) {
@@ -469,13 +520,17 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
       setIsPlaying(false);
       setIsPausing(false);
       stopRaf();
-      lastClearedBvRef.current = '';
+      lastClearedTrackRef.current = '';
       clearPlayNext();
       return;
     }
+    // 决定起始 P：显式 :p<n> 优先，其次 video-page-pref store 的 defaultPage，最后 P1。
+    // 通过 getState() 读取偏好（非订阅），避免用户偏好变化触发当前曲目重新加载。
+    const bvid = currentVideo.bvid;
+    const startPage = explicitPage ?? useVideoPagePrefStore.getState().getDefaultPage(bvid) ?? 1;
     setHasLyricFetchTry(false);
-    initHowl(currentVideo);
-  }, [playNext, currentVideo, initHowl, clearPlayNext, stopRaf]);
+    void initHowl(currentVideo, startPage);
+  }, [playNext, currentTrackId, currentVideo, explicitPage, initHowl, clearPlayNext, stopRaf]);
 
   // 音量变化同步到 Howl
   useEffect(() => {
@@ -530,7 +585,10 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
     if (!currentVideo) return;
     const howl = howlRef.current;
     if (!howl) {
-      initHowl(currentVideo);
+      // 没有 Howl 实例：从用户当前 TrackId / 默认 P 起播
+      const bvid = currentVideo.bvid;
+      const startPage = explicitPage ?? useVideoPagePrefStore.getState().getDefaultPage(bvid) ?? 1;
+      void initHowl(currentVideo, startPage);
       return;
     }
     if (howl.playing()) {
@@ -538,7 +596,7 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
     } else {
       howl.play();
     }
-  }, [isLoading, currentVideo, initHowl]);
+  }, [isLoading, currentVideo, explicitPage, initHowl]);
 
   const seek = useCallback((seconds: number) => {
     const howl = howlRef.current;
@@ -639,6 +697,21 @@ export function useMusicPlayer(): PlayerState & PlayerControls {
     // 把 seek 函数引用注册到 store，供 LyricViewer 等订阅方双击歌词跳转使用
     usePlayerRuntimeStore.setState({ seek });
   }, [seek]);
+
+  // 注册 switchToPage：让 PlayingQueue 等外部组件可请求切到当前投稿的指定 P
+  // 不动 usePlayingListStore.current（保持用户视角 TrackId 稳定），仅重建 Howl
+  useEffect(() => {
+    const switchToPage = (page: number) => {
+      if (!currentVideo) return;
+      const totalP = currentVideo.videos ?? 1;
+      const target = Math.max(1, Math.min(totalP, Math.floor(page)));
+      void initHowl(currentVideo, target);
+    };
+    usePlayerRuntimeStore.setState({ switchToPage });
+    return () => {
+      usePlayerRuntimeStore.setState({ switchToPage: undefined });
+    };
+  }, [currentVideo, initHowl]);
 
   // 进度同步到 setPositionState（每秒采样 progressRef，避免 RAF 60Hz setProgress 让 effect 反复重建定时器）
   useEffect(() => {

--- a/packages/web/src/lib/init.test.ts
+++ b/packages/web/src/lib/init.test.ts
@@ -197,7 +197,8 @@ describe('F2: initializeApp', () => {
     await init.initializeApp();
 
     expect(shared.useFavListStore.getState().list).toHaveLength(1);
-    expect(shared.usePlayingListStore.getState().bvIds).toEqual(['BV1', 'BV2']);
+    // hydrate 兼容性：旧 bvIds 字段被正确读到新的 trackIds 字段
+    expect(shared.usePlayingListStore.getState().trackIds).toEqual(['BV1', 'BV2']);
     expect(shared.usePlayerProfileStore.getState().theme).toBe('dark');
     expect(shared.usePlayerProfileStore.getState().volume).toBe(0.5);
     expect(shared.useLyricsStore.getState().lyricMaps).toHaveProperty('BV1');

--- a/packages/web/src/pages/fav-list.test.tsx
+++ b/packages/web/src/pages/fav-list.test.tsx
@@ -4,6 +4,7 @@ import {
   useBilibiliUserVideosStore,
   useBilibiliVideosStore,
   useFavListStore,
+  useFavoritesStore,
   useUIStore,
   FavListType,
 } from '@shuoshuo-player/shared';
@@ -47,6 +48,7 @@ function reset() {
   });
   useBilibiliVideosStore.setState({ ids: [], entities: {} });
   useUIStore.setState({ notices: [] });
+  useFavoritesStore.setState({ entries: {} });
 }
 
 function makeFav(overrides: Record<string, unknown> = {}) {
@@ -170,6 +172,58 @@ describe('FavListPage', () => {
 
     renderAt('u1');
     expect(screen.getByTestId('fav-card')).toBeInTheDocument();
+  });
+
+  it('favorites favId：空 favorites → 显示"歌单是空的"', () => {
+    renderAt('favorites');
+    expect(screen.getByText(/歌单是空的/)).toBeInTheDocument();
+    expect(screen.getByTestId('fav-card')).toHaveAttribute('data-favid', 'favorites');
+  });
+
+  it('favorites favId：3 条按时间倒序排列', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1', 'BV2', 'BV3'],
+      entities: {
+        BV1: { bvid: 'BV1', title: 'A' } as never,
+        BV2: { bvid: 'BV2', title: 'B' } as never,
+        BV3: { bvid: 'BV3', title: 'C' } as never,
+      },
+    });
+    useFavoritesStore.setState({ entries: { BV1: 100, BV2: 300, BV3: 200 } });
+
+    renderAt('favorites');
+    // 显示排序按钮（默认 desc）
+    expect(screen.getByRole('button', { name: /最新收藏在前/ })).toBeInTheDocument();
+  });
+
+  it('favorites favId：点击 toggle 切换到正序', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1', 'BV2'],
+      entities: {
+        BV1: { bvid: 'BV1', title: 'A' } as never,
+        BV2: { bvid: 'BV2', title: 'B' } as never,
+      },
+    });
+    useFavoritesStore.setState({ entries: { BV1: 100, BV2: 200 } });
+
+    renderAt('favorites');
+    const toggleBtn = screen.getByRole('button', { name: /最新收藏在前/ });
+    act(() => {
+      fireEvent.click(toggleBtn);
+    });
+    expect(screen.getByRole('button', { name: /最早收藏在前/ })).toBeInTheDocument();
+  });
+
+  it('favorites favId：FavCard 接收 type=CUSTOM 的虚拟项', () => {
+    useBilibiliVideosStore.setState({
+      ids: ['BV1'],
+      entities: { BV1: { bvid: 'BV1', title: 'A' } as never },
+    });
+    useFavoritesStore.setState({ entries: { BV1: 100 } });
+
+    renderAt('favorites');
+    // 虚拟 FavListItem 名称为「我的收藏」
+    expect(screen.getByTestId('fav-card')).toHaveTextContent('我的收藏');
   });
 
   it('BILI_FAV 歌单：从 favFolders 读取列表', () => {

--- a/packages/web/src/pages/fav-list.tsx
+++ b/packages/web/src/pages/fav-list.tsx
@@ -223,9 +223,12 @@ export function FavListPage() {
               {favoritesOrder === 'desc' ? '最新收藏在前' : '最早收藏在前'}
             </Button>
           )}
-          <span className="text-xs text-muted-foreground">
-            {filteredVideos.length} / {favVideoList.length}
-          </span>
+          {/* 总数已在 FavCard 标题旁显示，这里只在搜索时显示命中情况 */}
+          {searchKey && (
+            <span className="text-xs text-muted-foreground">
+              命中 {filteredVideos.length} / {favVideoList.length}
+            </span>
+          )}
         </div>
       )}
 

--- a/packages/web/src/pages/fav-list.tsx
+++ b/packages/web/src/pages/fav-list.tsx
@@ -19,6 +19,7 @@ import {
   useFavoritesStore,
   useUIStore,
   selectSortedBvids,
+  parseTrackId,
   NoticeType,
   type BilibiliVideo,
   type FavListItem,
@@ -91,35 +92,43 @@ export function FavListPage() {
 
   const isTypeCustom = favListInfo?.type === FavListType.CUSTOM;
 
-  // 根据类型计算视频列表
-  const favVideoList = useMemo<BilibiliVideo[]>(() => {
+  /**
+   * 歌单条目元组：trackId + 解析出的 bvid/explicitPage + 关联 video entity
+   *
+   * CUSTOM / favorites 的 trackId 可能含 :p<n>，store 按 bvid 索引 entity，
+   * 因此需 parseTrackId 拆出 bvid 查表后保留 explicitPage 给 VideoItem 渲染角标。
+   * UPLOADER / BILI_FAV 的条目永远是纯 bvid（写入侧已校验拦截）。
+   */
+  type FavRow = { trackId: string; video: BilibiliVideo; explicitPage?: number };
+  const favVideoList = useMemo<FavRow[]>(() => {
     if (!favListInfo) return [];
-    // 我的收藏：bv_ids 由 favorites store 派生，按当前排序模式
+    const mapTrackId = (trackId: string): FavRow | null => {
+      const parsed = parseTrackId(trackId);
+      const bvid = parsed?.bvid ?? trackId;
+      const video = videoEntities[bvid];
+      if (!video) return null;
+      return { trackId, video, explicitPage: parsed?.page };
+    };
     if (isFavoritesPage) {
       return selectSortedBvids(favoritesEntries, favoritesOrder)
-        .map((bvid) => videoEntities[bvid])
-        .filter((v): v is BilibiliVideo => Boolean(v));
+        .map(mapTrackId)
+        .filter((r): r is FavRow => r !== null);
     }
     if (favListInfo.type === FavListType.UPLOADER) {
-      const mid = favListInfo.mid ?? '';
-      const entry = userVideoInfos[mid];
+      const entry = userVideoInfos[favListInfo.mid ?? ''];
       if (!entry) return [];
       return entry.video_list
-        .map((it) => videoEntities[it.bvid])
-        .filter((v): v is BilibiliVideo => Boolean(v));
+        .map((it) => mapTrackId(it.bvid))
+        .filter((r): r is FavRow => r !== null);
     }
     if (favListInfo.type === FavListType.BILI_FAV) {
-      const folderId = favListInfo.biliFavFolderId ?? '';
-      const entry = favFolderInfos[folderId];
+      const entry = favFolderInfos[favListInfo.biliFavFolderId ?? ''];
       if (!entry) return [];
       return entry.video_list
-        .map((it) => videoEntities[it.bvid])
-        .filter((v): v is BilibiliVideo => Boolean(v));
+        .map((it) => mapTrackId(it.bvid))
+        .filter((r): r is FavRow => r !== null);
     }
-    // CUSTOM
-    return favListInfo.bv_ids
-      .map((bvid) => videoEntities[bvid])
-      .filter((v): v is BilibiliVideo => Boolean(v));
+    return favListInfo.bv_ids.map(mapTrackId).filter((r): r is FavRow => r !== null);
   }, [
     favListInfo,
     isFavoritesPage,
@@ -131,10 +140,11 @@ export function FavListPage() {
   ]);
 
   // Fuse.js 多字段搜索（v1 仅 title；v2 扩为 title/author/sub_title/description）
+  // 注：keys 走嵌套字段 video.title，与新 FavRow 形态对齐
   const fuse = useMemo(
     () =>
       new Fuse(favVideoList, {
-        keys: ['title', 'author', 'sub_title', 'description'],
+        keys: ['video.title', 'video.author', 'video.sub_title', 'video.description'],
         threshold: 0.3,
         ignoreLocation: true,
       }),
@@ -154,7 +164,7 @@ export function FavListPage() {
     overscan: 5,
   });
 
-  const handleRemoveSong = (bvid: string) => {
+  const handleRemoveSong = (trackId: string) => {
     if (!isTypeCustom) return;
     const isFav = isFavoritesPage;
     openConfirm({
@@ -163,9 +173,9 @@ export function FavListPage() {
       destructive: true,
       onConfirm: () => {
         if (isFav) {
-          useFavoritesStore.getState().remove(bvid);
+          useFavoritesStore.getState().remove(trackId);
         } else {
-          removeFavVideo(favId, bvid);
+          removeFavVideo(favId, trackId);
         }
         sendNotice({ type: NoticeType.SUCCESS, message: '已移除', duration: 2000 });
       },
@@ -261,7 +271,7 @@ export function FavListPage() {
             }}
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
-              const video = filteredVideos[virtualRow.index];
+              const row = filteredVideos[virtualRow.index];
               return (
                 <div
                   key={virtualRow.key}
@@ -277,12 +287,13 @@ export function FavListPage() {
                 >
                   <div className="px-2 py-1">
                     <VideoItem
-                      video={video}
+                      video={row.video}
+                      explicitPage={row.explicitPage}
                       favId={favId}
                       fullCreateTime
                       showAuthor={isTypeCustom}
                       showRemoveBtn={isTypeCustom}
-                      onRemove={handleRemoveSong}
+                      onRemove={() => handleRemoveSong(row.trackId)}
                     />
                   </div>
                 </div>

--- a/packages/web/src/pages/fav-list.tsx
+++ b/packages/web/src/pages/fav-list.tsx
@@ -2,17 +2,27 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Fuse from 'fuse.js';
-import { Search, X, AlertCircle, FolderOpen } from 'lucide-react';
+import {
+  Search,
+  X,
+  AlertCircle,
+  FolderOpen,
+  ArrowDownNarrowWide,
+  ArrowUpNarrowWide,
+} from 'lucide-react';
 import {
   MASTER_UP_INFO,
   FavListType,
   useBilibiliUserVideosStore,
   useBilibiliVideosStore,
   useFavListStore,
+  useFavoritesStore,
   useUIStore,
+  selectSortedBvids,
   NoticeType,
   type BilibiliVideo,
   type FavListItem,
+  type FavoritesOrder,
 } from '@shuoshuo-player/shared';
 import { useUIShell } from '@/stores/ui-shell';
 import { VideoItem } from '@/components/video-item';
@@ -21,6 +31,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
 const MAIN_FAV_ID = 'main';
+const FAVORITES_FAV_ID = 'favorites';
 const MASTER_MID = String(MASTER_UP_INFO.mid);
 const ROW_HEIGHT = 108;
 
@@ -35,15 +46,28 @@ const MAIN_FAV_ITEM: FavListItem = {
   update_time: 0,
 };
 
+/** 系统级「我的收藏」虚拟条目：复用 CUSTOM 渲染路径，bv_ids 由 favorites store 派生 */
+const FAVORITES_FAV_ITEM: FavListItem = {
+  id: FAVORITES_FAV_ID,
+  name: '我的收藏',
+  type: FavListType.CUSTOM,
+  bv_ids: [],
+  create_time: 0,
+  update_time: 0,
+};
+
 export function FavListPage() {
   const params = useParams<{ id: string }>();
   const favId = params.id ?? MAIN_FAV_ID;
 
   const [searchKey, setSearchKey] = useState('');
+  const [favoritesOrder, setFavoritesOrder] = useState<FavoritesOrder>('desc');
   const parentRef = useRef<HTMLDivElement>(null);
 
   const favList = useFavListStore((s) => s.list);
   const removeFavVideo = useFavListStore((s) => s.removeFavVideo);
+
+  const favoritesEntries = useFavoritesStore((s) => s.entries);
 
   const userVideoInfos = useBilibiliUserVideosStore((s) => s.infos);
   const favFolderInfos = useBilibiliUserVideosStore((s) => s.favFolders);
@@ -57,8 +81,11 @@ export function FavListPage() {
     setSearchKey('');
   }, [favId]);
 
+  const isFavoritesPage = favId === FAVORITES_FAV_ID;
+
   const favListInfo = useMemo<FavListItem | null>(() => {
     if (favId === MAIN_FAV_ID) return MAIN_FAV_ITEM;
+    if (favId === FAVORITES_FAV_ID) return FAVORITES_FAV_ITEM;
     return favList.find((f) => f.id === favId) ?? null;
   }, [favId, favList]);
 
@@ -67,6 +94,12 @@ export function FavListPage() {
   // 根据类型计算视频列表
   const favVideoList = useMemo<BilibiliVideo[]>(() => {
     if (!favListInfo) return [];
+    // 我的收藏：bv_ids 由 favorites store 派生，按当前排序模式
+    if (isFavoritesPage) {
+      return selectSortedBvids(favoritesEntries, favoritesOrder)
+        .map((bvid) => videoEntities[bvid])
+        .filter((v): v is BilibiliVideo => Boolean(v));
+    }
     if (favListInfo.type === FavListType.UPLOADER) {
       const mid = favListInfo.mid ?? '';
       const entry = userVideoInfos[mid];
@@ -87,7 +120,15 @@ export function FavListPage() {
     return favListInfo.bv_ids
       .map((bvid) => videoEntities[bvid])
       .filter((v): v is BilibiliVideo => Boolean(v));
-  }, [favListInfo, userVideoInfos, favFolderInfos, videoEntities]);
+  }, [
+    favListInfo,
+    isFavoritesPage,
+    favoritesEntries,
+    favoritesOrder,
+    userVideoInfos,
+    favFolderInfos,
+    videoEntities,
+  ]);
 
   // Fuse.js 多字段搜索（v1 仅 title；v2 扩为 title/author/sub_title/description）
   const fuse = useMemo(
@@ -115,12 +156,17 @@ export function FavListPage() {
 
   const handleRemoveSong = (bvid: string) => {
     if (!isTypeCustom) return;
+    const isFav = isFavoritesPage;
     openConfirm({
-      title: '移除歌曲',
-      description: '确定从歌单中移除这首歌吗？',
+      title: isFav ? '取消收藏' : '移除歌曲',
+      description: isFav ? '确定从我的收藏中移除这首歌吗？' : '确定从歌单中移除这首歌吗？',
       destructive: true,
       onConfirm: () => {
-        removeFavVideo(favId, bvid);
+        if (isFav) {
+          useFavoritesStore.getState().remove(bvid);
+        } else {
+          removeFavVideo(favId, bvid);
+        }
         sendNotice({ type: NoticeType.SUCCESS, message: '已移除', duration: 2000 });
       },
     });
@@ -162,6 +208,21 @@ export function FavListPage() {
               </Button>
             )}
           </div>
+          {isFavoritesPage && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 shrink-0 gap-1"
+              onClick={() => setFavoritesOrder((o) => (o === 'desc' ? 'asc' : 'desc'))}
+            >
+              {favoritesOrder === 'desc' ? (
+                <ArrowDownNarrowWide className="h-3.5 w-3.5" />
+              ) : (
+                <ArrowUpNarrowWide className="h-3.5 w-3.5" />
+              )}
+              {favoritesOrder === 'desc' ? '最新收藏在前' : '最早收藏在前'}
+            </Button>
+          )}
           <span className="text-xs text-muted-foreground">
             {filteredVideos.length} / {favVideoList.length}
           </span>

--- a/packages/web/src/pages/home.test.tsx
+++ b/packages/web/src/pages/home.test.tsx
@@ -46,7 +46,7 @@ function reset() {
     isLoading: false,
   });
   useBilibiliVideosStore.setState({ ids: [], entities: {} });
-  usePlayingListStore.setState({ favId: '', bvIds: [], current: '', playNext: false });
+  usePlayingListStore.setState({ favId: '', trackIds: [], current: '', playNext: false });
 }
 
 function makeVideoEntries(count: number) {
@@ -170,7 +170,7 @@ describe('HomePage', () => {
 
     const state = usePlayingListStore.getState();
     expect(state.favId).toBe('main');
-    expect(state.bvIds).toHaveLength(10);
+    expect(state.trackIds).toHaveLength(10);
     // 第 2 个 slide 对应第 2 个 video
     expect(state.current).toBe('BV0000000002');
     expect(state.playNext).toBe(true);

--- a/packages/web/src/pages/home.tsx
+++ b/packages/web/src/pages/home.tsx
@@ -68,8 +68,8 @@ export function HomePage() {
 
   const handleSlideClick = (video: BilibiliVideo) => {
     // 点击轮播图：替换播放队列为最近 30 条并立即播放当前曲
-    const bvIds = latestVideos.map((v) => v.bvid);
-    setPlaylist(MAIN_FAV_ID, bvIds, video.bvid, true);
+    const trackIds = latestVideos.map((v) => v.bvid);
+    setPlaylist(MAIN_FAV_ID, trackIds, video.bvid, true);
   };
 
   const handleManualUpdate = (mode: 'default' | 'fully') => {
@@ -106,9 +106,7 @@ export function HomePage() {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold">最新投稿</h2>
-          {spaceInfo?.name && (
-            <p className="text-xs text-muted-foreground">{spaceInfo.name}</p>
-          )}
+          {spaceInfo?.name && <p className="text-xs text-muted-foreground">{spaceInfo.name}</p>}
         </div>
         <Button
           variant="outline"

--- a/packages/web/src/pages/settings/appearance.test.tsx
+++ b/packages/web/src/pages/settings/appearance.test.tsx
@@ -1,11 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { usePlayerProfileStore, DEFAULT_PRIMARY_COLOR } from '@shuoshuo-player/shared';
+import {
+  usePlayerProfileStore,
+  DEFAULT_FLOATING_LYRICS,
+  DEFAULT_PRIMARY_COLOR,
+} from '@shuoshuo-player/shared';
 import { AppearanceSettings } from './appearance';
 
 function reset() {
   usePlayerProfileStore.setState({
     theme: 'auto',
     primaryColor: DEFAULT_PRIMARY_COLOR,
+    floatingLyrics: { ...DEFAULT_FLOATING_LYRICS },
   });
 }
 
@@ -49,8 +54,63 @@ describe('AppearanceSettings', () => {
   it('恢复默认按钮 → 重置主色', () => {
     usePlayerProfileStore.setState({ primaryColor: '100 50% 50%' });
     render(<AppearanceSettings />);
-    fireEvent.click(screen.getByRole('button', { name: /恢复默认/ }));
+    // 主色 Card 和悬浮歌词 Card 都有"恢复默认"按钮，按 DOM 顺序主色 Card 在前
+    const resetButtons = screen.getAllByRole('button', { name: /恢复默认/ });
+    fireEvent.click(resetButtons[0]);
     expect(usePlayerProfileStore.getState().primaryColor).toBe(DEFAULT_PRIMARY_COLOR);
+  });
+
+  describe('悬浮歌词 Card', () => {
+    it('总开关 Switch 默认开启', () => {
+      render(<AppearanceSettings />);
+      const sw = screen.getByRole('switch', { name: /启用悬浮歌词/ }) as HTMLButtonElement;
+      expect(sw.getAttribute('data-state')).toBe('checked');
+    });
+
+    it('点击总开关 → 翻转 floatingLyrics.enabled', () => {
+      render(<AppearanceSettings />);
+      const sw = screen.getByRole('switch', { name: /启用悬浮歌词/ }) as HTMLButtonElement;
+      fireEvent.click(sw);
+      expect(usePlayerProfileStore.getState().floatingLyrics.enabled).toBe(false);
+      fireEvent.click(sw);
+      expect(usePlayerProfileStore.getState().floatingLyrics.enabled).toBe(true);
+    });
+
+    it('字号 slider 变更 → setFloatingLyrics.fontSize', () => {
+      render(<AppearanceSettings />);
+      const slider = screen.getByLabelText(/字号/) as HTMLInputElement;
+      fireEvent.change(slider, { target: { value: '20' } });
+      expect(usePlayerProfileStore.getState().floatingLyrics.fontSize).toBe(20);
+    });
+
+    it('点击字重 加粗 → setFloatingLyrics.fontWeight=bold', () => {
+      render(<AppearanceSettings />);
+      fireEvent.click(screen.getByRole('button', { name: /加粗/ }));
+      expect(usePlayerProfileStore.getState().floatingLyrics.fontWeight).toBe('bold');
+    });
+
+    it('点击对齐 靠左 → setFloatingLyrics.textAlign=left', () => {
+      render(<AppearanceSettings />);
+      fireEvent.click(screen.getByRole('button', { name: '靠左' }));
+      expect(usePlayerProfileStore.getState().floatingLyrics.textAlign).toBe('left');
+    });
+
+    it('恢复默认按钮在 default 状态下 disabled', () => {
+      render(<AppearanceSettings />);
+      const resetButtons = screen.getAllByRole('button', { name: /恢复默认/ });
+      // 索引 1 = 悬浮歌词 Card 的恢复默认
+      expect((resetButtons[1] as HTMLButtonElement).disabled).toBe(true);
+    });
+
+    it('调整后点恢复默认 → 重置 floatingLyrics 全部字段', () => {
+      usePlayerProfileStore.setState({
+        floatingLyrics: { ...DEFAULT_FLOATING_LYRICS, fontSize: 24, fontWeight: 'bold' },
+      });
+      render(<AppearanceSettings />);
+      const resetButtons = screen.getAllByRole('button', { name: /恢复默认/ });
+      fireEvent.click(resetButtons[1]);
+      expect(usePlayerProfileStore.getState().floatingLyrics).toEqual(DEFAULT_FLOATING_LYRICS);
+    });
   });
 
   it('autoPlayNextPage toggle 默认关闭，点击后开启 store 字段（D4）', () => {

--- a/packages/web/src/pages/settings/appearance.test.tsx
+++ b/packages/web/src/pages/settings/appearance.test.tsx
@@ -52,4 +52,15 @@ describe('AppearanceSettings', () => {
     fireEvent.click(screen.getByRole('button', { name: /恢复默认/ }));
     expect(usePlayerProfileStore.getState().primaryColor).toBe(DEFAULT_PRIMARY_COLOR);
   });
+
+  it('autoPlayNextPage toggle 默认关闭，点击后开启 store 字段（D4）', () => {
+    usePlayerProfileStore.setState({ autoPlayNextPage: false });
+    render(<AppearanceSettings />);
+    const sw = screen.getByRole('switch', { name: /多 P 投稿连续播放/ }) as HTMLButtonElement;
+    expect(sw.getAttribute('data-state')).toBe('unchecked');
+    fireEvent.click(sw);
+    expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(true);
+    fireEvent.click(sw);
+    expect(usePlayerProfileStore.getState().autoPlayNextPage).toBe(false);
+  });
 });

--- a/packages/web/src/pages/settings/appearance.tsx
+++ b/packages/web/src/pages/settings/appearance.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
-import { Sun, Moon, Monitor, RotateCcw } from 'lucide-react';
+import { Sun, Moon, Monitor, RotateCcw, FlaskConical } from 'lucide-react';
 import { usePlayerProfileStore, DEFAULT_PRIMARY_COLOR } from '@shuoshuo-player/shared';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 
 const THEME_OPTIONS: Array<{
   value: 'light' | 'dark' | 'auto';
@@ -53,6 +54,8 @@ export function AppearanceSettings() {
   const primaryColor = usePlayerProfileStore((s) => s.primaryColor);
   const setPrimaryColor = usePlayerProfileStore((s) => s.setPrimaryColor);
   const resetPrimaryColor = usePlayerProfileStore((s) => s.resetPrimaryColor);
+  const autoPlayNextPage = usePlayerProfileStore((s) => s.autoPlayNextPage);
+  const setAutoPlayNextPage = usePlayerProfileStore((s) => s.setAutoPlayNextPage);
 
   const [hueDraft, setHueDraft] = useState<number>(() => parseHue(primaryColor));
   // 用户期望的"基础亮度"。色轮拖动时 L 仅做色相补偿夹紧不写回该值，
@@ -200,6 +203,39 @@ export function AppearanceSettings() {
               <RotateCcw className="mr-1 h-3.5 w-3.5" />
               恢复默认
             </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            播放行为
+            <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-normal text-amber-600 dark:text-amber-400">
+              <FlaskConical className="h-3 w-3" />
+              实验性
+            </span>
+          </CardTitle>
+          <CardDescription>多 P 投稿播放策略，可随时切换。</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1 space-y-1">
+              <Label htmlFor="auto-play-next-page" className="cursor-pointer text-sm font-medium">
+                多 P 投稿连续播放
+              </Label>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                开启后，播放多 P 视频投稿（如 Live 切片合辑、翻唱专辑）时，播放完一 P 会自动继续下一
+                P，直到所有 P 播完才切下一首。 关闭时（默认），多 P 投稿与单 P
+                投稿表现一致——一首结束即切下一首。
+              </p>
+            </div>
+            <Switch
+              id="auto-play-next-page"
+              checked={autoPlayNextPage}
+              onCheckedChange={setAutoPlayNextPage}
+              aria-label="多 P 投稿连续播放"
+            />
           </div>
         </CardContent>
       </Card>

--- a/packages/web/src/pages/settings/appearance.tsx
+++ b/packages/web/src/pages/settings/appearance.tsx
@@ -1,10 +1,30 @@
 import { useState, useEffect, useRef } from 'react';
-import { Sun, Moon, Monitor, RotateCcw, FlaskConical } from 'lucide-react';
-import { usePlayerProfileStore, DEFAULT_PRIMARY_COLOR } from '@shuoshuo-player/shared';
+import {
+  Sun,
+  Moon,
+  Monitor,
+  RotateCcw,
+  FlaskConical,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+} from 'lucide-react';
+import {
+  usePlayerProfileStore,
+  DEFAULT_FLOATING_LYRICS,
+  DEFAULT_PRIMARY_COLOR,
+  type FloatingLyricsAlign,
+  type FloatingLyricsColor,
+  type FloatingLyricsConfig,
+  type FloatingLyricsFamily,
+  type FloatingLyricsWeight,
+} from '@shuoshuo-player/shared';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
+import { FloatingLyrics } from '@/components/player/floating-lyrics';
 
 const THEME_OPTIONS: Array<{
   value: 'light' | 'dark' | 'auto';
@@ -56,6 +76,9 @@ export function AppearanceSettings() {
   const resetPrimaryColor = usePlayerProfileStore((s) => s.resetPrimaryColor);
   const autoPlayNextPage = usePlayerProfileStore((s) => s.autoPlayNextPage);
   const setAutoPlayNextPage = usePlayerProfileStore((s) => s.setAutoPlayNextPage);
+  const floatingLyrics = usePlayerProfileStore((s) => s.floatingLyrics);
+  const setFloatingLyrics = usePlayerProfileStore((s) => s.setFloatingLyrics);
+  const resetFloatingLyrics = usePlayerProfileStore((s) => s.resetFloatingLyrics);
 
   const [hueDraft, setHueDraft] = useState<number>(() => parseHue(primaryColor));
   // 用户期望的"基础亮度"。色轮拖动时 L 仅做色相补偿夹紧不写回该值，
@@ -207,6 +230,12 @@ export function AppearanceSettings() {
         </CardContent>
       </Card>
 
+      <FloatingLyricsCard
+        cfg={floatingLyrics}
+        setCfg={setFloatingLyrics}
+        resetCfg={resetFloatingLyrics}
+      />
+
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -254,4 +283,253 @@ function parseSL(hsl: string): { s: number; l: number } {
   const m = hsl.trim().match(/^[0-9.]+\s+([0-9.]+)%\s+([0-9.]+)%$/);
   if (!m) return { s: 83, l: 53 };
   return { s: parseFloat(m[1]), l: parseFloat(m[2]) };
+}
+
+/* ───────────────── 悬浮歌词 Card ───────────────── */
+
+const FAMILY_OPTIONS: Array<{ value: FloatingLyricsFamily; label: string }> = [
+  { value: 'sans', label: '无衬线' },
+  { value: 'serif', label: '衬线' },
+  { value: 'mono', label: '等宽' },
+];
+
+const WEIGHT_OPTIONS: Array<{ value: FloatingLyricsWeight; label: string }> = [
+  { value: 'normal', label: '常规' },
+  { value: 'bold', label: '加粗' },
+];
+
+const ALIGN_OPTIONS: Array<{
+  value: FloatingLyricsAlign;
+  label: string;
+  icon: typeof AlignLeft;
+}> = [
+  { value: 'left', label: '靠左', icon: AlignLeft },
+  { value: 'center', label: '居中', icon: AlignCenter },
+  { value: 'right', label: '靠右', icon: AlignRight },
+];
+
+const COLOR_OPTIONS: Array<{ value: FloatingLyricsColor; label: string; swatch: string }> = [
+  { value: 'primary', label: '跟随主色', swatch: 'hsl(var(--primary))' },
+  { value: 'white', label: '纯白', swatch: '#ffffff' },
+  { value: 'black', label: '纯黑', swatch: '#000000' },
+  { value: 'muted', label: '次要文字', swatch: 'hsl(var(--muted-foreground))' },
+];
+
+function isFloatingLyricsDefault(cfg: FloatingLyricsConfig): boolean {
+  return (
+    cfg.enabled === DEFAULT_FLOATING_LYRICS.enabled &&
+    cfg.fontSize === DEFAULT_FLOATING_LYRICS.fontSize &&
+    cfg.fontWeight === DEFAULT_FLOATING_LYRICS.fontWeight &&
+    cfg.fontFamily === DEFAULT_FLOATING_LYRICS.fontFamily &&
+    cfg.textAlign === DEFAULT_FLOATING_LYRICS.textAlign &&
+    cfg.verticalOffset === DEFAULT_FLOATING_LYRICS.verticalOffset &&
+    cfg.textColor === DEFAULT_FLOATING_LYRICS.textColor &&
+    cfg.bgOpacity === DEFAULT_FLOATING_LYRICS.bgOpacity
+  );
+}
+
+// 跟随主色预设在 store 里以 '' 形式保存（保持与默认值兼容），UI 显示统一映射成 'primary'。
+function effectiveColorKey(c: FloatingLyricsColor): Exclude<FloatingLyricsColor, ''> {
+  return c === '' ? 'primary' : c;
+}
+
+interface FloatingLyricsCardProps {
+  cfg: FloatingLyricsConfig;
+  setCfg: (patch: Partial<FloatingLyricsConfig>) => void;
+  resetCfg: () => void;
+}
+
+function FloatingLyricsCard({ cfg, setCfg, resetCfg }: FloatingLyricsCardProps) {
+  const { enabled } = cfg;
+  const colorKey = effectiveColorKey(cfg.textColor);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>悬浮歌词</CardTitle>
+        <CardDescription>
+          播放时显示在底部播放栏上方的当前歌词条。可独立开关，与全屏歌词页解耦。
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex items-center justify-between gap-4">
+          <Label htmlFor="floating-lyrics-enabled" className="cursor-pointer text-sm font-medium">
+            启用悬浮歌词
+          </Label>
+          <Switch
+            id="floating-lyrics-enabled"
+            checked={enabled}
+            onCheckedChange={(v) => setCfg({ enabled: Boolean(v) })}
+            aria-label="启用悬浮歌词"
+          />
+        </div>
+
+        <div
+          className={cn(
+            'space-y-5 transition-opacity',
+            enabled ? '' : 'pointer-events-none opacity-50',
+          )}
+          aria-disabled={!enabled}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="fl-size" className="text-xs text-muted-foreground">
+              字号（{cfg.fontSize}px）
+            </Label>
+            <input
+              id="fl-size"
+              type="range"
+              min={12}
+              max={32}
+              step={1}
+              value={cfg.fontSize}
+              onChange={(e) => setCfg({ fontSize: Number(e.target.value) })}
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted"
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">字重</Label>
+              <div className="flex flex-wrap gap-2">
+                {WEIGHT_OPTIONS.map((opt) => (
+                  <Button
+                    key={opt.value}
+                    type="button"
+                    variant={cfg.fontWeight === opt.value ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCfg({ fontWeight: opt.value })}
+                  >
+                    {opt.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label className="text-xs text-muted-foreground">字体</Label>
+              <div className="flex flex-wrap gap-2">
+                {FAMILY_OPTIONS.map((opt) => (
+                  <Button
+                    key={opt.value}
+                    type="button"
+                    variant={cfg.fontFamily === opt.value ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCfg({ fontFamily: opt.value })}
+                  >
+                    {opt.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs text-muted-foreground">对齐</Label>
+            <div className="flex flex-wrap gap-2">
+              {ALIGN_OPTIONS.map((opt) => {
+                const Icon = opt.icon;
+                return (
+                  <Button
+                    key={opt.value}
+                    type="button"
+                    variant={cfg.textAlign === opt.value ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setCfg({ textAlign: opt.value })}
+                    aria-label={opt.label}
+                  >
+                    <Icon className="mr-1.5 h-4 w-4" />
+                    {opt.label}
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="fl-offset" className="text-xs text-muted-foreground">
+              垂直偏移（{cfg.verticalOffset}px）
+            </Label>
+            <input
+              id="fl-offset"
+              type="range"
+              min={16}
+              max={64}
+              step={1}
+              value={cfg.verticalOffset}
+              onChange={(e) => setCfg({ verticalOffset: Number(e.target.value) })}
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs text-muted-foreground">文字色</Label>
+            <div className="flex flex-wrap gap-2">
+              {COLOR_OPTIONS.map((opt) => {
+                const active = colorKey === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setCfg({ textColor: opt.value })}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs transition-colors',
+                      active
+                        ? 'border-primary ring-2 ring-primary/30'
+                        : 'border-border hover:border-muted-foreground',
+                    )}
+                    aria-pressed={active}
+                  >
+                    <span
+                      className="h-4 w-4 rounded-full border border-border"
+                      style={{ backgroundColor: opt.swatch }}
+                    />
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="fl-bg" className="text-xs text-muted-foreground">
+              整体不透明度（{Math.round(cfg.bgOpacity * 100)}%）
+            </Label>
+            <input
+              id="fl-bg"
+              type="range"
+              min={0}
+              max={100}
+              step={5}
+              value={Math.round(cfg.bgOpacity * 100)}
+              onChange={(e) => setCfg({ bgOpacity: Number(e.target.value) / 100 })}
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-muted"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="text-xs text-muted-foreground">预览</Label>
+            {/* 外层留出顶部空间承载悬浮歌词；内层伪 footer 作为 FloatingLyrics 的 relative 锚点 */}
+            <div className="rounded border bg-muted/40 px-3 pb-3 pt-32">
+              <div className="relative h-8 rounded bg-muted-foreground/15 text-center text-[10px] leading-8 text-muted-foreground">
+                模拟底部播放栏
+                <FloatingLyrics line="预览：当前播放的歌词条" visible={true} />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={resetCfg}
+            disabled={isFloatingLyricsDefault(cfg)}
+          >
+            <RotateCcw className="mr-1 h-3.5 w-3.5" />
+            恢复默认
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
 }

--- a/packages/web/src/pages/settings/appearance.tsx
+++ b/packages/web/src/pages/settings/appearance.tsx
@@ -248,17 +248,10 @@ export function AppearanceSettings() {
           <CardDescription>多 P 投稿播放策略，可随时切换。</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 flex-1 space-y-1">
-              <Label htmlFor="auto-play-next-page" className="cursor-pointer text-sm font-medium">
-                多 P 投稿连续播放
-              </Label>
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                开启后，播放多 P 视频投稿（如 Live 切片合辑、翻唱专辑）时，播放完一 P 会自动继续下一
-                P，直到所有 P 播完才切下一首。 关闭时（默认），多 P 投稿与单 P
-                投稿表现一致——一首结束即切下一首。
-              </p>
-            </div>
+          <div className="flex items-center justify-between gap-4">
+            <Label htmlFor="auto-play-next-page" className="cursor-pointer text-sm font-medium">
+              多 P 投稿连续播放
+            </Label>
             <Switch
               id="auto-play-next-page"
               checked={autoPlayNextPage}

--- a/packages/web/src/pages/settings/index.tsx
+++ b/packages/web/src/pages/settings/index.tsx
@@ -49,8 +49,8 @@ export function SettingsPage() {
       onValueChange={handleTabChange}
       className="-mx-6 -my-4 flex h-[calc(100%+2rem)] flex-col"
     >
-      {/* 头部跨整宽，border-b 顶到 NavMenu 分隔线；TabsList 在 max-w 居中容器内左对齐 */}
-      <div className="flex-none border-b">
+      {/* 头部跨整宽，border-t 接 TopBar 视觉延续；TabsList 在 max-w 居中容器内左对齐 */}
+      <div className="flex-none border-t">
         <div className="mx-auto max-w-3xl px-6 py-3">
           <TabsList>
             {availableTabs.includes('appearance') && (

--- a/packages/web/src/stores/player-runtime.ts
+++ b/packages/web/src/stores/player-runtime.ts
@@ -16,9 +16,18 @@ interface PlayerRuntimeState {
   duration: number;
   /** 跳转到指定秒数。useMusicPlayer 主控 hook mount 时注册；未注册时为 undefined（noop） */
   seek?: (seconds: number) => void;
+  /** 当前实际播放的分 P（与 store.current TrackId 解耦的运行时状态；自 C3 起由 useMusicPlayer 同步） */
+  playingPage: number;
+  /**
+   * 切换到当前 bvid 的指定分 P（主控 hook 注册）。
+   * 调用方（PlayingQueue / SPlayer P 选择器）通过它请求重载音频流；
+   * 内部仅触发 Howl 重建，不动 usePlayingListStore.current（保持用户视角 TrackId 稳定）。
+   */
+  switchToPage?: (page: number) => void;
 }
 
 export const usePlayerRuntimeStore = create<PlayerRuntimeState>(() => ({
   progress: 0,
   duration: 0,
+  playingPage: 1,
 }));

--- a/packages/web/src/stores/ui-shell.ts
+++ b/packages/web/src/stores/ui-shell.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { FavListType } from '@shuoshuo-player/shared';
+import type { BilibiliVideo, FavListType } from '@shuoshuo-player/shared';
 
 /** 新建模式下预填字段（仅 type/mid/name；编辑模式忽略） */
 export interface FavEditPrefill {
@@ -39,6 +39,12 @@ interface UIShellState {
   /** 批量添加多条到歌单（搜索发现页批量选择模式入口） */
   openAddToFavBatch: (bvids: string[], options?: { fromSearch?: boolean }) => void;
   closeAddToFav: () => void;
+
+  /** PagesPickerDialog：VideoItem 三点菜单触发，多选分 P 加入歌单 */
+  pagesPickerOpen: boolean;
+  pagesPickerVideo: BilibiliVideo | null;
+  openPagesPicker: (video: BilibiliVideo) => void;
+  closePagesPicker: () => void;
 
   /** 通用确认弹窗 */
   confirmOpen: boolean;
@@ -108,6 +114,11 @@ export const useUIShell = create<UIShellState>((set) => ({
       addToFavExcludeId: null,
       addToFavFromSearch: false,
     }),
+
+  pagesPickerOpen: false,
+  pagesPickerVideo: null,
+  openPagesPicker: (video) => set({ pagesPickerOpen: true, pagesPickerVideo: video }),
+  closePagesPicker: () => set({ pagesPickerOpen: false, pagesPickerVideo: null }),
 
   confirmOpen: false,
   confirmConfig: null,


### PR DESCRIPTION
## Summary

汇总 dev 分支自 v1.9.1 以来累积的 7 个提交，准备发布 **v1.9.2**。

### 新增
- 悬浮歌词独立开关 + 8 字段样式自定义（设置 → 外观「悬浮歌词」Card）
- B 站投稿分 P 支持；分 P 选择器多选加歌单
- 「我的收藏」系统级歌单 + 左侧栏 UI 重排
- VideoItem 双击 / 封面单击播放

### 变更
- 左下角封面成为唯一全屏歌词入口，hover 显示 Expand 蒙层
- 悬浮歌词定位采用 `bottom:100% + translateY` 二段定位，规避 grid+overflow 嵌套下 calc 失效

### 修复
- 修复快速切歌导致的双音频并发播放竞态
- 收藏夹歌单页显示与 FavCard 体验优化

完整变更见 [CHANGELOG.md](https://github.com/LanceLRQ/shuoshuo-player/blob/dev/CHANGELOG.md#192---待发布)。

## Test plan

- [x] `pnpm lint`（0 errors）
- [x] `pnpm typecheck`（shared / web / desktop 全通过）
- [x] `pnpm test:coverage`（shared 431 + web 489 + desktop 73 = 993 用例全过）
- [x] `pnpm build:extension`（产物 1339 KiB，远低于 10240 KiB 预算）
- [x] 手测：清 localStorage 启动 → 默认悬浮歌词显示，右下按钮切换；左下封面 hover 显示 Expand + 黑蒙层，点击进全屏歌词
- [x] 手测：设置 → 外观 → 悬浮歌词 Card 各项 → 预览即时反映 → 切回播放器观察 footer 实际样式一致
- [x] 手测：刷新页面 / 重启后悬浮歌词配置持久化生效
- [x] 手测：desktop 端（`pnpm dev:desktop`）与 extension 端走一遍核心交互

## Release notes

发版时通过 `pnpm release` 走 `scripts/release.sh` 流程：
- 输入新版本 **1.9.2**
- `pnpm version:sync` 自动同步 7 处版本号
- tag `v1.9.2` push 后触发 `.github/workflows/release.yml` 产出 Chrome 扩展 + macOS arm64 + Windows x64 安装包