### PR TITLE
feat: 桌面端 cookie 混淆/托盘截断 + Web 首页轮播与合集列表多项 UI 改进

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -23,6 +23,7 @@
 - 主窗口右键 →「检查元素」打开 DevTools，体验与 Chrome 一致
 - Rust 端日志：`println!` / `tracing` 输出到 `pnpm dev:desktop` 终端
 - Cookie 存储：`tauri-plugin-store` 写入 `bilibili_cookies.json`，路径取决于平台 app data dir
+  - 落盘内容经 XOR 流混淆（防肉眼 / 文本扫描，非真加密），直接打开文件看不到明文；旧明文文件首次启动自动迁移
   - macOS: `~/Library/Application Support/<bundle-id>/`
   - Windows: `%APPDATA%/<bundle-id>/`
   - Linux: `~/.local/share/<bundle-id>/`

--- a/packages/desktop/src-tauri/src/commands/auth.rs
+++ b/packages/desktop/src-tauri/src/commands/auth.rs
@@ -7,9 +7,11 @@
 // 3. Cookie 持久化前剥离 session=false 标记，否则关闭应用后 cookie 丢失
 // 4. 登出后清除 CookieState + 关主窗 + 重新弹登录窗口（v1 行为）
 //
-// CookieState 当前以 in-memory + tauri-plugin-store 文件 bilibili_cookies.json 落地；
+// CookieState 当前以 in-memory + tauri-plugin-store 文件 bilibili_cookies.json 落地，
+// 落盘前对 cookie 列表做 XOR 流混淆（详见本文件 obfuscate_cookies）；
 // reqwest cookie store 共享将在 spider 命令实装时统一接通（批 4）。
 
+use base64::Engine;
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_store::StoreExt;
@@ -17,6 +19,20 @@ use tauri_plugin_store::StoreExt;
 const BILIBILI_LOGIN_URL: &str = "https://passport.bilibili.com/pc/passport/login";
 const COOKIES_STORE_FILE_NAME: &str = "bilibili_cookies.json";
 const COOKIES_STORE_KEY: &str = "cookies";
+
+/// cookie 混淆格式版本前缀（bilibili player cookie v1）。
+/// restore 时凭 JSON 值类型 + 此前缀区分新混淆串与 v2 早期明文数组。
+const COOKIES_OBFUSCATE_PREFIX: &str = "BPC1:";
+
+/// 固定 32B 混淆 key。
+///
+/// 不绑机器（区别于 audio_cache 的 machine-uid 派生 key），以保证 portable 模式下
+/// data 目录连同混淆文件拷到另一台机器仍可解。安全立场同 audio_cache：仅做"防肉眼 /
+/// 防文本扫描"的误识别防护，不是真加密——开源 + 本地应用密钥无处安放，加密拦不住逆向。
+const COOKIES_OBFUSCATE_KEY: [u8; 32] = [
+    0x3a, 0x9f, 0x71, 0xc4, 0x18, 0xe6, 0x5d, 0x2b, 0x84, 0xf0, 0x6c, 0x39, 0xa7, 0x1e, 0xd2, 0x58,
+    0x0b, 0x95, 0x4f, 0xe3, 0x77, 0x2c, 0xb8, 0x61, 0xda, 0x07, 0x93, 0x4e, 0xc1, 0x35, 0xa9, 0x6f,
+];
 
 /// portable 模式：返回 <exe_dir>/data/bilibili_cookies.json 绝对路径；
 /// 非 portable 模式：返回相对名（plugin-store 走 app_data_dir）
@@ -59,11 +75,55 @@ pub fn strip_sessions(cookies: &mut [CookieRecord]) {
     }
 }
 
+/// 就地 XOR：32B key 循环 + 位置混入（`^ i as u8`），让 SESSDATA 这类长字符串
+/// 不暴露 32 字节周期的重复 pattern。XOR 无 padding 且对称，混淆与解混是同一运算。
+fn xor_cookies_in_place(buf: &mut [u8]) {
+    for (i, b) in buf.iter_mut().enumerate() {
+        *b ^= COOKIES_OBFUSCATE_KEY[i & 0x1F] ^ (i as u8);
+    }
+}
+
+/// cookie 列表 → 带版本前缀的混淆 base64 字符串
+fn obfuscate_cookies(cookies: &[CookieRecord]) -> Result<String, String> {
+    let mut bytes = serde_json::to_vec(cookies).map_err(|e| e.to_string())?;
+    xor_cookies_in_place(&mut bytes);
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("{COOKIES_OBFUSCATE_PREFIX}{encoded}"))
+}
+
+/// 带版本前缀的混淆字符串 → cookie 列表（仅处理新混淆格式）
+fn deobfuscate_cookies(s: &str) -> Result<Vec<CookieRecord>, String> {
+    let encoded = s
+        .strip_prefix(COOKIES_OBFUSCATE_PREFIX)
+        .ok_or_else(|| "cookie 混淆前缀缺失".to_string())?;
+    let mut bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|e| e.to_string())?;
+    xor_cookies_in_place(&mut bytes);
+    serde_json::from_slice(&bytes).map_err(|e| e.to_string())
+}
+
+/// 解析 store 中持久化的 cookie 值，兼容两种磁盘格式。
+///
+/// 返回的 `bool` 为 true 表示命中 v2 早期明文数组（legacy），由调用方负责立即覆写迁移，
+/// 消除磁盘上残留的明文 SESSDATA。
+/// - JSON String（`"BPC1:..."`）→ 新混淆格式，false
+/// - JSON Array → v2 早期明文数组，true
+fn parse_stored_cookies(raw: serde_json::Value) -> Result<(Vec<CookieRecord>, bool), String> {
+    match raw {
+        serde_json::Value::String(s) => Ok((deobfuscate_cookies(&s)?, false)),
+        other => {
+            let cookies = serde_json::from_value(other).map_err(|e| e.to_string())?;
+            Ok((cookies, true))
+        }
+    }
+}
+
 /// 运行时 cookie 缓存（启动时从 bilibili_cookies.json 回放）
 #[derive(Default)]
 pub struct CookieState(pub Mutex<Vec<CookieRecord>>);
 
-/// 把 CookieState 当前内容剥离 session 后写入 bilibili_cookies.json
+/// 把 CookieState 当前内容剥离 session、XOR 混淆后写入 bilibili_cookies.json
 pub fn persist_cookies<R: Runtime>(
     app: &AppHandle<R>,
     state: &CookieState,
@@ -72,14 +132,12 @@ pub fn persist_cookies<R: Runtime>(
     strip_sessions(&mut cookies);
 
     let store = app.store(cookies_store_path()).map_err(|e| e.to_string())?;
-    store.set(
-        COOKIES_STORE_KEY.to_string(),
-        serde_json::to_value(&cookies).map_err(|e| e.to_string())?,
-    );
+    store.set(COOKIES_STORE_KEY.to_string(), obfuscate_cookies(&cookies)?);
     store.save().map_err(|e| e.to_string())
 }
 
-/// 从 bilibili_cookies.json 回放到 CookieState（应用启动时调用）
+/// 从 bilibili_cookies.json 回放到 CookieState（应用启动时调用）。
+/// 兼容读取 v2 早期明文数组格式，命中时立即覆写为混淆格式完成迁移。
 pub fn restore_cookies<R: Runtime>(
     app: &AppHandle<R>,
     state: &CookieState,
@@ -89,9 +147,15 @@ pub fn restore_cookies<R: Runtime>(
         Some(v) => v,
         None => return Ok(()),
     };
-    let cookies: Vec<CookieRecord> = serde_json::from_value(raw).map_err(|e| e.to_string())?;
-    let mut guard = state.0.lock().map_err(|e| e.to_string())?;
-    *guard = cookies;
+    let (cookies, is_legacy_plaintext) = parse_stored_cookies(raw)?;
+    {
+        let mut guard = state.0.lock().map_err(|e| e.to_string())?;
+        *guard = cookies;
+    }
+    // 命中 v2 早期明文格式 → 立即覆写为混淆格式，消除磁盘上残留的明文 SESSDATA
+    if is_legacy_plaintext {
+        persist_cookies(app, state).ok();
+    }
     Ok(())
 }
 
@@ -240,7 +304,10 @@ pub async fn bilibili_logout<R: Runtime>(app: AppHandle<R>) -> Result<(), String
 
 #[cfg(test)]
 mod tests {
-    use super::{strip_session, strip_sessions, CookieRecord};
+    use super::{
+        deobfuscate_cookies, obfuscate_cookies, parse_stored_cookies, strip_session,
+        strip_sessions, CookieRecord, COOKIES_OBFUSCATE_PREFIX,
+    };
 
     fn rec(name: &str, session: bool) -> CookieRecord {
         CookieRecord {
@@ -286,5 +353,49 @@ mod tests {
         let json = r#"{"name":"x","value":"y","domain":null,"path":null}"#;
         let parsed: CookieRecord = serde_json::from_str(json).unwrap();
         assert!(!parsed.session);
+    }
+
+    #[test]
+    fn obfuscate_deobfuscate_roundtrip() {
+        let cookies = vec![rec("SESSDATA", false), rec("buvid3", false)];
+        let blob = obfuscate_cookies(&cookies).unwrap();
+        let back = deobfuscate_cookies(&blob).unwrap();
+        assert_eq!(cookies, back);
+    }
+
+    #[test]
+    fn obfuscated_blob_hides_plaintext() {
+        let mut c = rec("SESSDATA", false);
+        c.value = "super-secret-token-value".into();
+        let blob = obfuscate_cookies(std::slice::from_ref(&c)).unwrap();
+        assert!(blob.starts_with(COOKIES_OBFUSCATE_PREFIX));
+        // 混淆串里不得出现明文 token 值与字段名
+        assert!(!blob.contains("super-secret-token-value"));
+        assert!(!blob.contains("SESSDATA"));
+    }
+
+    #[test]
+    fn deobfuscate_rejects_missing_prefix() {
+        // 无版本前缀的字符串应被拒绝，而非误解码
+        assert!(deobfuscate_cookies("not-a-valid-blob").is_err());
+    }
+
+    #[test]
+    fn parse_stored_new_format_string() {
+        let cookies = vec![rec("SESSDATA", false)];
+        let blob = obfuscate_cookies(&cookies).unwrap();
+        let (parsed, is_legacy) = parse_stored_cookies(serde_json::Value::String(blob)).unwrap();
+        assert_eq!(parsed, cookies);
+        assert!(!is_legacy);
+    }
+
+    #[test]
+    fn parse_stored_legacy_plaintext_array() {
+        // v2 早期明文数组应被识别为 legacy，触发迁移覆写
+        let cookies = vec![rec("SESSDATA", false), rec("DedeUserID", false)];
+        let raw = serde_json::to_value(&cookies).unwrap();
+        let (parsed, is_legacy) = parse_stored_cookies(raw).unwrap();
+        assert_eq!(parsed, cookies);
+        assert!(is_legacy);
     }
 }

--- a/packages/desktop/src/lib/tray-sync.test.ts
+++ b/packages/desktop/src/lib/tray-sync.test.ts
@@ -113,7 +113,7 @@ describe('tray-sync', () => {
     expect(togglePlay).toHaveBeenCalledTimes(1);
   });
 
-  it('长标题被截断到 40 字符 + 省略号', async () => {
+  it('长标题被截断到 15 字形 + 省略号', async () => {
     startTraySync();
     vi.advanceTimersByTime(250);
     await Promise.resolve();
@@ -131,8 +131,31 @@ describe('tray-sync', () => {
     const labelCall = mockInvoke.mock.calls.find((c) => c[0] === 'tray_set_track_label');
     expect(labelCall).toBeDefined();
     const label = labelCall![1].label as string;
-    expect(label.length).toBeLessThanOrEqual(40);
+    expect(Array.from(label).length).toBeLessThanOrEqual(15);
     expect(label.endsWith('…')).toBe(true);
+  });
+
+  it('含 emoji 的长标题按码点截断，不产生半个代理对', async () => {
+    startTraySync();
+    vi.advanceTimersByTime(250);
+    await Promise.resolve();
+    mockInvoke.mockClear();
+
+    const emojiTitle = '🎵'.repeat(20); // 每个 emoji 占 2 个 UTF-16 code unit
+    useBilibiliVideosStore.setState({
+      ids: ['BV4'],
+      entities: { BV4: makeVideo('BV4', emojiTitle, '') },
+    });
+    usePlayingListStore.setState({ current: 'BV4' });
+    vi.advanceTimersByTime(250);
+    await Promise.resolve();
+
+    const labelCall = mockInvoke.mock.calls.find((c) => c[0] === 'tray_set_track_label');
+    expect(labelCall).toBeDefined();
+    const label = labelCall![1].label as string;
+    expect(Array.from(label).length).toBeLessThanOrEqual(15);
+    // 不含孤立代理项（slice 截半 emoji 的产物）
+    expect(/\p{Surrogate}/u.test(label)).toBe(false);
   });
 
   it('同标签重复变化时去重（不触发额外 invoke）', async () => {

--- a/packages/desktop/src/lib/tray-sync.ts
+++ b/packages/desktop/src/lib/tray-sync.ts
@@ -7,8 +7,8 @@ import {
 import { usePlayerRuntimeStore } from '@/stores/player-runtime';
 import { setTrayPlayState, setTrayTrackLabel } from './tray-bridge';
 
-/** 标题最长 40 字符，超出加省略号，避免菜单变形（macOS menubar 宽度敏感） */
-const MAX_TRACK_LABEL_LENGTH = 40;
+/** 标题最长 15 字形，超出加省略号，避免菜单变形（macOS menubar 宽度敏感） */
+const MAX_TRACK_LABEL_LENGTH = 15;
 
 /** 标题/作者更新的尾沿节流窗口；切歌瞬间多次 setState 合并为一次 invoke */
 const LABEL_PUSH_THROTTLE_MS = 200;
@@ -36,9 +36,11 @@ function deriveTrackLabel(
   const video = entities[bvid];
   if (!video?.title) return '';
   const author = video.author ? ` - ${video.author}` : '';
-  let label = `♪ ${video.title}${author}`;
-  if (label.length > MAX_TRACK_LABEL_LENGTH) {
-    label = `${label.slice(0, MAX_TRACK_LABEL_LENGTH - 1)}…`;
+  const label = `♪ ${video.title}${author}`;
+  // 按 Unicode 码点截断：B 站标题常含 emoji，按 UTF-16 slice 会截断代理对产生乱码
+  const chars = Array.from(label);
+  if (chars.length > MAX_TRACK_LABEL_LENGTH) {
+    return `${chars.slice(0, MAX_TRACK_LABEL_LENGTH - 1).join('')}…`;
   }
   return label;
 }

--- a/packages/shared/src/store/middleware/persist.test.ts
+++ b/packages/shared/src/store/middleware/persist.test.ts
@@ -296,6 +296,24 @@ describe('STORE_PERSIST_REGISTRY hydrate/snapshot', () => {
     expect(snap.floatingLyrics?.textAlign).toBe('left');
   });
 
+  it('ui_profile hydrate 缺 home/favViewMode 时兜底默认（thumbnail / list）', () => {
+    // 模拟老用户快照不含视图模式字段
+    usePlayerProfileStore.setState({ homeViewMode: 'list', favViewMode: 'thumbnail' });
+    getEntry('ui_profile').hydrate({ theme: 'dark' });
+    expect(usePlayerProfileStore.getState().homeViewMode).toBe('thumbnail');
+    expect(usePlayerProfileStore.getState().favViewMode).toBe('list');
+  });
+
+  it('ui_profile snapshot 包含 home/favViewMode 字段', () => {
+    usePlayerProfileStore.setState({ homeViewMode: 'list', favViewMode: 'thumbnail' });
+    const snap = getEntry('ui_profile').snapshot() as {
+      homeViewMode?: string;
+      favViewMode?: string;
+    };
+    expect(snap.homeViewMode).toBe('list');
+    expect(snap.favViewMode).toBe('thumbnail');
+  });
+
   it('ui_profile hydrate 缺失 closeAction 字段时兜底为默认值且 prompted=false', () => {
     // 模拟老用户：snapshot 完全没这俩字段
     usePlayerProfileStore.setState({

--- a/packages/shared/src/store/middleware/persist.ts
+++ b/packages/shared/src/store/middleware/persist.ts
@@ -25,7 +25,9 @@ import type { FavFolderCacheEntry, VideoListCacheEntry } from '../../types';
 import {
   DEFAULT_CLOSE_ACTION,
   DEFAULT_COLLECTION_PLAY_BEHAVIOR,
+  DEFAULT_FAV_VIEW_MODE,
   DEFAULT_FLOATING_LYRICS,
+  DEFAULT_HOME_VIEW_MODE,
 } from '../../types';
 import type {
   PersistedBilibiliUserVideosShape,
@@ -243,6 +245,8 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
         closeAction: data.closeAction ?? DEFAULT_CLOSE_ACTION,
         closeActionFirstRunPrompted: data.closeActionFirstRunPrompted ?? false,
         collectionPlayBehavior: data.collectionPlayBehavior ?? DEFAULT_COLLECTION_PLAY_BEHAVIOR,
+        homeViewMode: data.homeViewMode ?? DEFAULT_HOME_VIEW_MODE,
+        favViewMode: data.favViewMode ?? DEFAULT_FAV_VIEW_MODE,
       });
     },
     snapshot() {
@@ -258,6 +262,8 @@ export const STORE_PERSIST_REGISTRY: ReadonlyArray<StorePersistEntry> = [
         closeAction: s.closeAction,
         closeActionFirstRunPrompted: s.closeActionFirstRunPrompted,
         collectionPlayBehavior: s.collectionPlayBehavior,
+        homeViewMode: s.homeViewMode,
+        favViewMode: s.favViewMode,
       };
     },
     subscribe(cb) {

--- a/packages/shared/src/store/persisted-types.ts
+++ b/packages/shared/src/store/persisted-types.ts
@@ -20,6 +20,7 @@ import type {
   LoopMode,
   LyricEntry,
   VideoListCacheEntry,
+  VideoListViewMode,
 } from '../types';
 import type { MusicUrlCacheEntry } from './music-url-cache';
 import type { UpdateInfo } from '../api/update';
@@ -69,6 +70,10 @@ export interface PersistedPlayerProfileShape {
   closeActionFirstRunPrompted?: boolean;
   /** 「以合集为歌单播放」按钮的队列行为；老用户缺该字段时 fallback DEFAULT_COLLECTION_PLAY_BEHAVIOR */
   collectionPlayBehavior?: CollectionPlayBehavior;
+  /** 首页列表展示模式；老用户缺该字段时 hydrate fallback DEFAULT_HOME_VIEW_MODE */
+  homeViewMode?: VideoListViewMode;
+  /** 歌单列表展示模式；fallback DEFAULT_FAV_VIEW_MODE */
+  favViewMode?: VideoListViewMode;
 }
 
 export interface PersistedLyricsShape {

--- a/packages/shared/src/store/player-profile.test.ts
+++ b/packages/shared/src/store/player-profile.test.ts
@@ -2,7 +2,9 @@ import { usePlayerProfileStore } from './player-profile';
 import {
   DEFAULT_CLOSE_ACTION,
   DEFAULT_COLLECTION_PLAY_BEHAVIOR,
+  DEFAULT_FAV_VIEW_MODE,
   DEFAULT_FLOATING_LYRICS,
+  DEFAULT_HOME_VIEW_MODE,
 } from '../types';
 
 function reset() {
@@ -15,6 +17,8 @@ function reset() {
     closeAction: DEFAULT_CLOSE_ACTION,
     closeActionFirstRunPrompted: false,
     collectionPlayBehavior: DEFAULT_COLLECTION_PLAY_BEHAVIOR,
+    homeViewMode: DEFAULT_HOME_VIEW_MODE,
+    favViewMode: DEFAULT_FAV_VIEW_MODE,
   });
 }
 
@@ -230,6 +234,29 @@ describe('usePlayerProfileStore', () => {
       // @ts-expect-error 测试非法值
       usePlayerProfileStore.getState().setCollectionPlayBehavior('queue');
       expect(usePlayerProfileStore.getState().collectionPlayBehavior).toBe('append');
+    });
+  });
+
+  describe('视图模式偏好（home / fav）', () => {
+    it('默认值：home=thumbnail / fav=list', () => {
+      expect(usePlayerProfileStore.getState().homeViewMode).toBe(DEFAULT_HOME_VIEW_MODE);
+      expect(usePlayerProfileStore.getState().favViewMode).toBe(DEFAULT_FAV_VIEW_MODE);
+      expect(DEFAULT_HOME_VIEW_MODE).toBe('thumbnail');
+      expect(DEFAULT_FAV_VIEW_MODE).toBe('list');
+    });
+
+    it('setHomeViewMode / setFavViewMode 切换合法枚举', () => {
+      usePlayerProfileStore.getState().setHomeViewMode('list');
+      expect(usePlayerProfileStore.getState().homeViewMode).toBe('list');
+      usePlayerProfileStore.getState().setFavViewMode('thumbnail');
+      expect(usePlayerProfileStore.getState().favViewMode).toBe('thumbnail');
+    });
+
+    it('非法值被忽略（防御导入脏数据）', () => {
+      usePlayerProfileStore.getState().setHomeViewMode('list');
+      // @ts-expect-error 测试非法值
+      usePlayerProfileStore.getState().setHomeViewMode('grid');
+      expect(usePlayerProfileStore.getState().homeViewMode).toBe('list');
     });
   });
 

--- a/packages/shared/src/store/player-profile.ts
+++ b/packages/shared/src/store/player-profile.ts
@@ -9,11 +9,14 @@ import type {
   FloatingLyricsColor,
   LoopMode,
   PlayerProfile,
+  VideoListViewMode,
 } from '../types';
 import {
   DEFAULT_CLOSE_ACTION,
   DEFAULT_COLLECTION_PLAY_BEHAVIOR,
+  DEFAULT_FAV_VIEW_MODE,
   DEFAULT_FLOATING_LYRICS,
+  DEFAULT_HOME_VIEW_MODE,
   DEFAULT_PRIMARY_COLOR,
 } from '../types';
 
@@ -24,6 +27,11 @@ const CLOSE_ACTION_SET: ReadonlySet<CloseAction> = new Set<CloseAction>([
 
 const COLLECTION_PLAY_BEHAVIOR_SET: ReadonlySet<CollectionPlayBehavior> =
   new Set<CollectionPlayBehavior>(['replace', 'append']);
+
+const VIEW_MODE_SET: ReadonlySet<VideoListViewMode> = new Set<VideoListViewMode>([
+  'list',
+  'thumbnail',
+]);
 
 const FLOATING_LYRICS_ALIGN_SET: ReadonlySet<FloatingLyricsAlign> = new Set([
   'left',
@@ -106,6 +114,10 @@ interface PlayerProfileState extends PlayerProfile {
    * 设置「以合集为歌单播放」按钮的队列行为；非法枚举值忽略以防御导入脏数据。
    */
   setCollectionPlayBehavior: (behavior: CollectionPlayBehavior) => void;
+  /** 设置首页列表展示模式；非白名单值忽略以防御导入脏数据 */
+  setHomeViewMode: (mode: VideoListViewMode) => void;
+  /** 设置歌单列表展示模式（所有歌单共享）；非白名单值忽略以防御导入脏数据 */
+  setFavViewMode: (mode: VideoListViewMode) => void;
   /** 解析 'auto' 主题为实际 light/dark（依赖 prefers-color-scheme） */
   getEffectiveTheme: () => 'light' | 'dark';
 }
@@ -121,6 +133,8 @@ export const usePlayerProfileStore = create<PlayerProfileState>((set, get) => ({
   closeAction: DEFAULT_CLOSE_ACTION,
   closeActionFirstRunPrompted: false,
   collectionPlayBehavior: DEFAULT_COLLECTION_PLAY_BEHAVIOR,
+  homeViewMode: DEFAULT_HOME_VIEW_MODE,
+  favViewMode: DEFAULT_FAV_VIEW_MODE,
 
   setTheme: (theme) => set({ theme }),
   setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
@@ -148,6 +162,15 @@ export const usePlayerProfileStore = create<PlayerProfileState>((set, get) => ({
   setCollectionPlayBehavior: (behavior) => {
     if (!COLLECTION_PLAY_BEHAVIOR_SET.has(behavior)) return;
     set({ collectionPlayBehavior: behavior });
+  },
+
+  setHomeViewMode: (mode) => {
+    if (!VIEW_MODE_SET.has(mode)) return;
+    set({ homeViewMode: mode });
+  },
+  setFavViewMode: (mode) => {
+    if (!VIEW_MODE_SET.has(mode)) return;
+    set({ favViewMode: mode });
   },
 
   getEffectiveTheme: () => {

--- a/packages/shared/src/types/playlist.ts
+++ b/packages/shared/src/types/playlist.ts
@@ -100,6 +100,10 @@ export interface PlayerProfile {
    * 与播放器循环模式、单条点击行为正交，仅作用于合集详情顶部"以合集为歌单播放"按钮。
    */
   collectionPlayBehavior: CollectionPlayBehavior;
+  /** 首页「最新投稿」列表的展示模式；老用户缺该字段时 fallback DEFAULT_HOME_VIEW_MODE */
+  homeViewMode: VideoListViewMode;
+  /** 歌单页列表的展示模式（所有歌单共享一个偏好）；fallback DEFAULT_FAV_VIEW_MODE */
+  favViewMode: VideoListViewMode;
 }
 
 /** 默认强调色（与 packages/web/src/styles/globals.css 中 --primary 一致；#FF6687 中粉） */
@@ -132,3 +136,12 @@ export type CollectionPlayBehavior = 'replace' | 'append';
 
 /** 默认：替换当前队列。符合"现在听这个合集"的直觉用法 */
 export const DEFAULT_COLLECTION_PLAY_BEHAVIOR: CollectionPlayBehavior = 'replace';
+
+/** 视频列表展示模式：'list' 单行列表 / 'thumbnail' 3:2 封面网格 */
+export type VideoListViewMode = 'list' | 'thumbnail';
+
+/** 首页默认缩略图（封面优先，符合"浏览最新投稿"的直觉） */
+export const DEFAULT_HOME_VIEW_MODE: VideoListViewMode = 'thumbnail';
+
+/** 歌单默认列表（信息密度优先，符合"管理 / 检索歌曲"的场景） */
+export const DEFAULT_FAV_VIEW_MODE: VideoListViewMode = 'list';

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",

--- a/packages/web/src/components/carousel.tsx
+++ b/packages/web/src/components/carousel.tsx
@@ -7,12 +7,16 @@ import { Button } from '@/components/ui/button';
 
 interface CarouselProps<T> {
   slides: T[];
-  /** 渲染单张幻灯片 */
-  renderSlide: (item: T, index: number) => React.ReactNode;
+  /** 渲染单张幻灯片；isSelected 标识是否为当前居中的焦点张 */
+  renderSlide: (item: T, index: number, isSelected: boolean) => React.ReactNode;
   /** 自动播放间隔（ms），默认 4000，与 v1 对齐 */
   autoplayDelay?: number;
   /** 是否启用循环（默认 true） */
   loop?: boolean;
+  /** 对齐方式：'start' 左对齐（默认），'center' 居中并在两侧 peek 相邻张 */
+  align?: 'start' | 'center';
+  /** 每张 slide 外层 wrapper 的宽度/间距类；默认整宽 */
+  slideClassName?: string;
   className?: string;
   onSlideClick?: (item: T, index: number) => void;
 }
@@ -22,10 +26,12 @@ export function Carousel<T>({
   renderSlide,
   autoplayDelay = 4000,
   loop = true,
+  align = 'start',
+  slideClassName = 'flex-[0_0_100%]',
   className,
   onSlideClick,
 }: CarouselProps<T>) {
-  const [emblaRef, emblaApi] = useEmblaCarousel({ loop }, [
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop, align }, [
     Autoplay({ delay: autoplayDelay, stopOnInteraction: false }),
   ]);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -73,10 +79,10 @@ export function Carousel<T>({
           {slides.map((slide, index) => (
             <div
               key={index}
-              className="min-w-0 flex-[0_0_100%] cursor-pointer"
+              className={cn('min-w-0 cursor-pointer', slideClassName)}
               onClick={() => onSlideClick?.(slide, index)}
             >
-              {renderSlide(slide, index)}
+              {renderSlide(slide, index, index === selectedIndex)}
             </div>
           ))}
         </div>

--- a/packages/web/src/components/thumbnail-grid-card.test.tsx
+++ b/packages/web/src/components/thumbnail-grid-card.test.tsx
@@ -1,0 +1,97 @@
+import { type ReactNode } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { BilibiliVideo } from '@shuoshuo-player/shared';
+import { ThumbnailGridCard } from './thumbnail-grid-card';
+
+// mock context-menu：子组件直出 children，Item 用 click 触发 onSelect，规避 Radix portal/pointer
+vi.mock('@/components/ui/context-menu', () => {
+  const Pass = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    ContextMenu: Pass,
+    ContextMenuTrigger: Pass,
+    ContextMenuContent: Pass,
+    ContextMenuItem: ({ children, onSelect }: { children?: ReactNode; onSelect?: () => void }) => (
+      <button type="button" onClick={() => onSelect?.()}>
+        {children}
+      </button>
+    ),
+    ContextMenuSeparator: () => <hr />,
+    ContextMenuSub: Pass,
+    ContextMenuSubTrigger: Pass,
+    ContextMenuSubContent: Pass,
+  };
+});
+
+// mock hook：返回可控 actions，聚焦卡片的菜单项渲染/派发
+const mockActions = vi.hoisted(() => ({
+  effectiveTrackId: 'BV1',
+  isFavored: false,
+  isMultiPart: false,
+  partItems: [] as Array<{ key: number; page: number; part?: string }>,
+  defaultPage: 1,
+  toggleLike: vi.fn(),
+  addToPlay: vi.fn(),
+  addToFav: vi.fn(),
+  openPagesPicker: vi.fn(),
+  pinDefaultPage: vi.fn(),
+  openBilibili: vi.fn(),
+}));
+vi.mock('@/hooks/use-video-item-actions', () => ({
+  useVideoItemActions: () => mockActions,
+}));
+
+function makeVideo(overrides: Partial<BilibiliVideo> = {}): BilibiliVideo {
+  return { bvid: 'BV1', title: 'Track', videos: 1, ...overrides } as BilibiliVideo;
+}
+
+describe('ThumbnailGridCard 右键菜单', () => {
+  beforeEach(() => {
+    mockActions.isFavored = false;
+    mockActions.isMultiPart = false;
+    mockActions.partItems = [];
+    mockActions.defaultPage = 1;
+    vi.clearAllMocks();
+  });
+
+  it('单 P 不渲染分 P 相关菜单项', () => {
+    render(<ThumbnailGridCard video={makeVideo()} onClick={vi.fn()} />);
+    expect(screen.queryByText('选择分 P 添加到歌单')).not.toBeInTheDocument();
+    expect(screen.queryByText(/记住默认 P/)).not.toBeInTheDocument();
+  });
+
+  it('多 P 渲染分 P 菜单项', () => {
+    mockActions.isMultiPart = true;
+    mockActions.partItems = [
+      { key: 1, page: 1 },
+      { key: 2, page: 2 },
+    ];
+    render(<ThumbnailGridCard video={makeVideo({ videos: 2 })} onClick={vi.fn()} />);
+    expect(screen.getByText('选择分 P 添加到歌单')).toBeInTheDocument();
+    expect(screen.getByText(/记住默认 P/)).toBeInTheDocument();
+  });
+
+  it('无 onRemove 不渲染移除项；有 onRemove 渲染并可触发', () => {
+    const { rerender } = render(<ThumbnailGridCard video={makeVideo()} onClick={vi.fn()} />);
+    expect(screen.queryByText('移除歌曲')).not.toBeInTheDocument();
+
+    const onRemove = vi.fn();
+    rerender(<ThumbnailGridCard video={makeVideo()} onClick={vi.fn()} onRemove={onRemove} />);
+    fireEvent.click(screen.getByText('移除歌曲'));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it('点收藏触发 toggleLike，点菜单播放触发 onClick', () => {
+    const onClick = vi.fn();
+    render(<ThumbnailGridCard video={makeVideo()} onClick={onClick} />);
+    fireEvent.click(screen.getByText('收藏'));
+    expect(mockActions.toggleLike).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByText('播放'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('isFavored=true 时显示「取消收藏」', () => {
+    mockActions.isFavored = true;
+    render(<ThumbnailGridCard video={makeVideo()} onClick={vi.fn()} />);
+    expect(screen.getByText('取消收藏')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/thumbnail-grid-card.tsx
+++ b/packages/web/src/components/thumbnail-grid-card.tsx
@@ -1,0 +1,99 @@
+import { memo, useState } from 'react';
+import { PlayCircle } from 'lucide-react';
+import { bilibiliThumbUrl, type BilibiliVideo } from '@shuoshuo-player/shared';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { PartBadge } from './part-badge';
+
+export interface ThumbnailGridCardProps {
+  video: BilibiliVideo;
+  /** 显式分 P（CUSTOM/favorites 歌单条目可能带 :p<n>），透传给 PartBadge 角标 */
+  explicitPage?: number;
+  /** 是否为当前正在播放条目（高亮态） */
+  isPlaying?: boolean;
+  onClick: () => void;
+}
+
+function ThumbnailGridCardImpl({
+  video,
+  explicitPage,
+  isPlaying,
+  onClick,
+}: ThumbnailGridCardProps) {
+  const [imgError, setImgError] = useState(false);
+  const isInvalid = video.invalid === true;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isInvalid}
+      // group/card：让 hover overlay 仅响应本卡 hover，与外层虚拟行隔离
+      className={cn(
+        'group/card flex w-full flex-col gap-1.5 rounded-md p-1 text-left transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        !isInvalid && 'hover:bg-accent/50',
+        isInvalid && 'cursor-default',
+        isPlaying && 'bg-accent',
+      )}
+      aria-label={isInvalid ? `${video.title}（已失效）` : `播放 ${video.title}`}
+    >
+      <div
+        className={cn(
+          'relative aspect-[3/2] w-full overflow-hidden rounded bg-muted',
+          isInvalid && 'grayscale',
+        )}
+      >
+        {!imgError && video.pic ? (
+          <img
+            // 300x200 = 3:2，object-cover 裁切宽度填满；bilibiliThumbUrl 内部已 urlPrefixFixed
+            src={bilibiliThumbUrl(video.pic, 300, 200)}
+            alt={video.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-200 group-hover/card:scale-105"
+            onError={() => setImgError(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <PlayCircle className="h-8 w-8" />
+          </div>
+        )}
+
+        {isInvalid && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/55">
+            <Badge variant="destructive" className="text-[10px]">
+              已失效
+            </Badge>
+          </div>
+        )}
+
+        {/* hover / 播放中 显示播放按钮（失效态不显示） */}
+        {!isInvalid && (
+          <div
+            className={cn(
+              'pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 transition-opacity duration-150',
+              isPlaying ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100',
+            )}
+          >
+            <PlayCircle className="h-10 w-10 text-white" />
+          </div>
+        )}
+
+        {/* 多 P 角标（单 P 时 PartBadge 内部返回 null） */}
+        <div className="pointer-events-none absolute bottom-1 right-1">
+          <PartBadge video={video} explicitPage={explicitPage} />
+        </div>
+      </div>
+
+      <p className={cn('line-clamp-2 text-sm font-medium leading-snug', isInvalid && 'opacity-60')}>
+        {video.title}
+      </p>
+    </button>
+  );
+}
+
+/**
+ * 缩略图网格单卡：3:2 封面 + 标题。功能刻意精简（仅播放），区别于功能繁重的 VideoItem。
+ * memo 包装避免虚拟网格滚动时未变化的卡重复 render。
+ */
+export const ThumbnailGridCard = memo(ThumbnailGridCardImpl);

--- a/packages/web/src/components/thumbnail-grid-card.tsx
+++ b/packages/web/src/components/thumbnail-grid-card.tsx
@@ -1,17 +1,41 @@
 import { memo, useState } from 'react';
-import { PlayCircle } from 'lucide-react';
+import {
+  Play,
+  PlayCircle,
+  Star,
+  Clock,
+  Plus,
+  Layers,
+  Pin,
+  PinOff,
+  ExternalLink,
+  Trash2,
+} from 'lucide-react';
 import { bilibiliThumbUrl, type BilibiliVideo } from '@shuoshuo-player/shared';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+} from '@/components/ui/context-menu';
 import { PartBadge } from './part-badge';
+import { useVideoItemActions } from '@/hooks/use-video-item-actions';
 
 export interface ThumbnailGridCardProps {
   video: BilibiliVideo;
-  /** 显式分 P（CUSTOM/favorites 歌单条目可能带 :p<n>），透传给 PartBadge 角标 */
+  /** 显式分 P（CUSTOM/favorites 歌单条目可能带 :p<n>），透传给 PartBadge 角标与操作 hook */
   explicitPage?: number;
   /** 是否为当前正在播放条目（高亮态） */
   isPlaying?: boolean;
   onClick: () => void;
+  /** 存在则渲染「移除歌曲」菜单项（仅歌单内注入；回调内部已含确认弹窗） */
+  onRemove?: () => void;
 }
 
 function ThumbnailGridCardImpl({
@@ -19,81 +43,172 @@ function ThumbnailGridCardImpl({
   explicitPage,
   isPlaying,
   onClick,
+  onRemove,
 }: ThumbnailGridCardProps) {
   const [imgError, setImgError] = useState(false);
   const isInvalid = video.invalid === true;
+  const actions = useVideoItemActions(video, explicitPage);
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isInvalid}
-      // group/card：让 hover overlay 仅响应本卡 hover，与外层虚拟行隔离
-      className={cn(
-        'group/card flex w-full flex-col gap-1.5 rounded-md p-1 text-left transition-colors',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        !isInvalid && 'hover:bg-accent/50',
-        isInvalid && 'cursor-default',
-        isPlaying && 'bg-accent',
-      )}
-      aria-label={isInvalid ? `${video.title}（已失效）` : `播放 ${video.title}`}
-    >
-      <div
-        className={cn(
-          'relative aspect-[3/2] w-full overflow-hidden rounded bg-muted',
-          isInvalid && 'grayscale',
-        )}
-      >
-        {!imgError && video.pic ? (
-          <img
-            // 300x200 = 3:2，object-cover 裁切宽度填满；bilibiliThumbUrl 内部已 urlPrefixFixed
-            src={bilibiliThumbUrl(video.pic, 300, 200)}
-            alt={video.title}
-            loading="lazy"
-            className="h-full w-full object-cover transition-transform duration-200 group-hover/card:scale-105"
-            onError={() => setImgError(true)}
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <PlayCircle className="h-8 w-8" />
-          </div>
-        )}
-
-        {isInvalid && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/55">
-            <Badge variant="destructive" className="text-[10px]">
-              已失效
-            </Badge>
-          </div>
-        )}
-
-        {/* hover / 播放中 显示播放按钮（失效态不显示） */}
-        {!isInvalid && (
+    <ContextMenu>
+      <ContextMenuTrigger asChild disabled={isInvalid}>
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={isInvalid}
+          // group/card：让 hover overlay 仅响应本卡 hover，与外层虚拟行隔离
+          className={cn(
+            'group/card flex w-full flex-col gap-1.5 rounded-md p-1 text-left transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            !isInvalid && 'hover:bg-accent/50',
+            isInvalid && 'cursor-default',
+            isPlaying && 'bg-accent',
+          )}
+          aria-label={isInvalid ? `${video.title}（已失效）` : `播放 ${video.title}`}
+        >
           <div
             className={cn(
-              'pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 transition-opacity duration-150',
-              isPlaying ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100',
+              'relative aspect-[3/2] w-full overflow-hidden rounded bg-muted',
+              isInvalid && 'grayscale',
             )}
           >
-            <PlayCircle className="h-10 w-10 text-white" />
+            {!imgError && video.pic ? (
+              <img
+                // 300x200 = 3:2，object-cover 裁切宽度填满；bilibiliThumbUrl 内部已 urlPrefixFixed
+                src={bilibiliThumbUrl(video.pic, 300, 200)}
+                alt={video.title}
+                loading="lazy"
+                className="h-full w-full object-cover transition-transform duration-200 group-hover/card:scale-105"
+                onError={() => setImgError(true)}
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                <PlayCircle className="h-8 w-8" />
+              </div>
+            )}
+
+            {isInvalid && (
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/55">
+                <Badge variant="destructive" className="text-[10px]">
+                  已失效
+                </Badge>
+              </div>
+            )}
+
+            {/* hover / 播放中 显示播放按钮（失效态不显示） */}
+            {!isInvalid && (
+              <div
+                className={cn(
+                  'pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 transition-opacity duration-150',
+                  isPlaying ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100',
+                )}
+              >
+                <PlayCircle className="h-10 w-10 text-white" />
+              </div>
+            )}
+
+            {/* 多 P 角标（单 P 时 PartBadge 内部返回 null） */}
+            <div className="pointer-events-none absolute bottom-1 right-1">
+              <PartBadge video={video} explicitPage={explicitPage} />
+            </div>
           </div>
+
+          <p
+            className={cn(
+              'line-clamp-2 text-sm font-medium leading-snug',
+              isInvalid && 'opacity-60',
+            )}
+          >
+            {video.title}
+          </p>
+        </button>
+      </ContextMenuTrigger>
+
+      <ContextMenuContent className="w-52">
+        <ContextMenuItem onSelect={onClick}>
+          <Play className="mr-2 h-4 w-4" />
+          播放
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={actions.toggleLike}>
+          <Star
+            className={cn('mr-2 h-4 w-4', actions.isFavored && 'fill-current text-yellow-500')}
+          />
+          {actions.isFavored ? '取消收藏' : '收藏'}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={actions.addToPlay}>
+          <Clock className="mr-2 h-4 w-4" />
+          稍后播放
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={actions.addToFav}>
+          <Plus className="mr-2 h-4 w-4" />
+          添加到歌单
+        </ContextMenuItem>
+        {actions.isMultiPart && (
+          <ContextMenuItem onSelect={actions.openPagesPicker}>
+            <Layers className="mr-2 h-4 w-4" />
+            选择分 P 添加到歌单
+          </ContextMenuItem>
         )}
-
-        {/* 多 P 角标（单 P 时 PartBadge 内部返回 null） */}
-        <div className="pointer-events-none absolute bottom-1 right-1">
-          <PartBadge video={video} explicitPage={explicitPage} />
-        </div>
-      </div>
-
-      <p className={cn('line-clamp-2 text-sm font-medium leading-snug', isInvalid && 'opacity-60')}>
-        {video.title}
-      </p>
-    </button>
+        {actions.isMultiPart && (
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <Pin className="mr-2 h-4 w-4" />
+              记住默认 P{actions.defaultPage >= 2 ? `（当前 P${actions.defaultPage}）` : ''}
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent className="max-h-[60vh] w-64 overflow-y-auto">
+              {actions.partItems.map((it) => (
+                <ContextMenuItem
+                  key={`pin-${it.key}`}
+                  onSelect={() => actions.pinDefaultPage(it.page)}
+                  className="min-w-0"
+                >
+                  <span
+                    className={cn(
+                      'mr-2 shrink-0 tabular-nums',
+                      actions.defaultPage === it.page
+                        ? 'font-semibold text-primary'
+                        : 'text-muted-foreground',
+                    )}
+                  >
+                    P{it.page}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{it.part || `分P ${it.page}`}</span>
+                </ContextMenuItem>
+              ))}
+              {actions.defaultPage >= 2 && (
+                <>
+                  <ContextMenuSeparator />
+                  <ContextMenuItem onSelect={() => actions.pinDefaultPage(1)}>
+                    <PinOff className="mr-2 h-4 w-4" />
+                    清除默认 P 设置
+                  </ContextMenuItem>
+                </>
+              )}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        )}
+        <ContextMenuItem onSelect={actions.openBilibili}>
+          <ExternalLink className="mr-2 h-4 w-4" />去 B 站看
+        </ContextMenuItem>
+        {onRemove && (
+          <>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+              onSelect={onRemove}
+              className="text-destructive focus:text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              移除歌曲
+            </ContextMenuItem>
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
 /**
- * 缩略图网格单卡：3:2 封面 + 标题。功能刻意精简（仅播放），区别于功能繁重的 VideoItem。
+ * 缩略图网格单卡：3:2 封面 + 标题 + 右键菜单（收藏/稍后播放/添加歌单/分P/去B站/移除）。
  * memo 包装避免虚拟网格滚动时未变化的卡重复 render。
  */
 export const ThumbnailGridCard = memo(ThumbnailGridCardImpl);

--- a/packages/web/src/components/ui/context-menu.tsx
+++ b/packages/web/src/components/ui/context-menu.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const ContextMenu = ContextMenuPrimitive.Root;
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & { inset?: boolean }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & { inset?: boolean }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+};

--- a/packages/web/src/components/uploader-seasons-tab.tsx
+++ b/packages/web/src/components/uploader-seasons-tab.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useSearchParams } from 'react-router-dom';
 import {
   ArrowLeft,
@@ -8,6 +9,8 @@ import {
   ListMusic,
   ListPlus,
   PlayCircle,
+  Search,
+  X,
 } from 'lucide-react';
 import {
   NoticeType,
@@ -30,14 +33,18 @@ import {
 import { useUIShell } from '@/stores/ui-shell';
 import { SeasonCard } from '@/components/season-card';
 import { VideoItem } from '@/components/video-item';
+import { ViewModeToggle } from '@/components/view-mode-toggle';
+import { ThumbnailGridCard } from '@/components/thumbnail-grid-card';
 import { MediaLoadingDialog } from '@/components/dialogs/media-loading-dialog';
 import { PageRangeDialog } from '@/components/dialogs/page-range-dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 /* ───────── 批次配置 ───────── */
@@ -83,6 +90,8 @@ interface UploaderSeasonsTabProps {
   mid: string;
   /** 当前所属歌单 ID，透传给 VideoItem 用于单条点击 addSingle 行为 */
   favId: string;
+  /** 合集详情 header 的 Portal 目标（父级 Tab 行的 slot）；缺省时 header 内联渲染 */
+  headerSlot?: HTMLElement | null;
 }
 
 const COLLECTION_QUERY_RE = /^(season|series):(\d+)$/;
@@ -106,7 +115,7 @@ function parseCollectionQuery(raw: string | null): OpenedCollection | null {
  * series API 详情接口本身不返回 meta，需要从列表态把 name/cover/description 透传过去
  * 才能让 header 立即显示正确标题（而不是 "加载中…"）。
  */
-export function UploaderSeasonsTab({ mid, favId }: UploaderSeasonsTabProps) {
+export function UploaderSeasonsTab({ mid, favId, headerSlot }: UploaderSeasonsTabProps) {
   const [params, setParams] = useSearchParams();
   const opened = parseCollectionQuery(params.get('collection'));
   const collections = useUploaderCollections(mid);
@@ -139,6 +148,7 @@ export function UploaderSeasonsTab({ mid, favId }: UploaderSeasonsTabProps) {
         fallback={openedCollection}
         favId={favId}
         onBack={handleBack}
+        headerSlot={headerSlot}
       />
     );
   }
@@ -211,9 +221,11 @@ interface SeasonDetailProps {
   fallback?: UploaderCollection;
   favId: string;
   onBack: () => void;
+  /** 合集详情 header 的 Portal 目标（父级 Tab 行的 slot）；缺省时内联渲染 */
+  headerSlot?: HTMLElement | null;
 }
 
-function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProps) {
+function SeasonDetail({ mid, opened, fallback, favId, onBack, headerSlot }: SeasonDetailProps) {
   const fallbackMeta = useMemo(
     () =>
       fallback
@@ -238,10 +250,16 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
 
   const setPlaylist = usePlayingListStore((s) => s.setPlaylist);
   const addSingle = usePlayingListStore((s) => s.addSingle);
+  const currentTrackId = usePlayingListStore((s) => s.current);
   const collectionPlayBehavior = usePlayerProfileStore((s) => s.collectionPlayBehavior);
+  const favViewMode = usePlayerProfileStore((s) => s.favViewMode);
+  const setFavViewMode = usePlayerProfileStore((s) => s.setFavViewMode);
   const sendNotice = useUIStore((s) => s.sendNotice);
   const openAddToFavBatch = useUIShell((s) => s.openAddToFavBatch);
   const openConfirm = useUIShell((s) => s.openConfirm);
+
+  // 合集详情内搜索：仅过滤当前页已加载的视频（不发起新请求）
+  const [searchKey, setSearchKey] = useState('');
 
   /**
    * 累积用户分页过程中浏览过的所有视频。
@@ -280,6 +298,17 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
     () => pickVideosFields(archives, 'season') as BilibiliVideo[],
     [archives],
   );
+
+  // 当前页本地过滤（标题 / 作者），不触发接口
+  const filteredVisible = useMemo<BilibiliVideo[]>(() => {
+    const kw = searchKey.trim().toLowerCase();
+    if (!kw) return visibleVideos;
+    return visibleVideos.filter((v) => {
+      const title = v.title?.toLowerCase() ?? '';
+      const author = v.author?.toLowerCase() ?? '';
+      return title.includes(kw) || author.includes(kw);
+    });
+  }, [visibleVideos, searchKey]);
 
   /**
    * 全量拉取的公共流程：防重入 + 触发 trigger + 空集合兜底通知。
@@ -423,7 +452,7 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
         ? `加载中 ${allArchives.loaded}/${allArchives.total}`
         : '加载中…';
     }
-    return '以合集为歌单播放';
+    return '播放合集';
   }, [allArchives.isLoading, allArchives.loaded, allArchives.total]);
 
   /** 按钮标签显示"已加载数量"：批量拉取与分页累积的去重总数（用 Set 算 bvid 并集） */
@@ -436,60 +465,98 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
   // 精简文案：窄屏下「加入歌单（150 首已加载）」会把按钮撑到 ~180px 挤压标题区
   const addToFavLabel = addToFavLoadedCount > 0 ? `加入歌单 (${addToFavLoadedCount})` : '加入歌单';
 
-  return (
-    <div className="flex flex-1 flex-col gap-3">
-      {/*
-       * 紧凑型 header：返回箭头 + 小封面 + 标题 + 数量 + 两个操作按钮。
-       * 容器用 flex-wrap：窄屏（Chrome 扩展弹窗 ~400px）下操作按钮组自动换到第二行，
-       * 避免按钮长文案把 min-w-0 标题区挤压到 0px。
-       * description 折叠到标题的 title 属性（hover tooltip），避免占用纵向空间。
-       */}
-      <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-card p-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onBack}
-          className="h-8 w-8 shrink-0"
-          aria-label="返回合集列表"
+  /*
+   * 合集详情 header（返回 + 封面 + 合集名·N首 + 收窄搜索框 + 视图切换 + 「播放合集」整合按钮）。
+   * 优先通过 Portal 提到父级 Tab 行（headerSlot），与「视频投稿/合集」Tab 合并成一行；
+   * 无 slot 时回退内联渲染。description 折叠到标题 title（hover tooltip）不占纵向空间。
+   */
+  const headerContent = (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onBack}
+        className="h-9 w-9 shrink-0"
+        aria-label="返回合集列表"
+      >
+        <ArrowLeft className="h-4 w-4" />
+      </Button>
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
+        {headerCover ? (
+          <img
+            src={bilibiliThumbUrl(urlPrefixFixed(headerCover), 80, 80)}
+            alt={headerName}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <ListMusic className="h-4 w-4 text-muted-foreground" />
+        )}
+      </div>
+      {/* 合集名 · N首 同一行：标题 truncate 吸收弹性空间，「N首」常驻不截断 */}
+      <div className="flex min-w-0 flex-1 basis-[120px] items-center gap-1.5">
+        <h3
+          className="min-w-0 truncate text-sm font-semibold leading-tight"
+          title={description || headerName}
         >
-          <ArrowLeft className="h-4 w-4" />
-        </Button>
-        <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
-          {headerCover ? (
-            <img
-              src={bilibiliThumbUrl(urlPrefixFixed(headerCover), 80, 80)}
-              alt={headerName}
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <ListMusic className="h-4 w-4 text-muted-foreground" />
+          {headerName}
+        </h3>
+        <span className="shrink-0 whitespace-nowrap text-xs text-muted-foreground mt-1">
+          {headerTotal} 首
+        </span>
+      </div>
+
+      {archives.length > 0 && (
+        <div className="relative w-40 shrink-0 sm:w-52">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="搜索当前页（标题 / 作者）"
+            value={searchKey}
+            onChange={(e) => setSearchKey(e.target.value)}
+            className="h-9 pl-9"
+          />
+          {searchKey && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2"
+              onClick={() => setSearchKey('')}
+            >
+              <X className="h-3 w-3" />
+            </Button>
           )}
         </div>
-        {/* basis-[140px]：保证标题区有最小宽度，否则 flex-wrap 不会触发换行 */}
-        <div className="min-w-0 flex-1 basis-[140px]">
-          <h3
-            className="truncate text-sm font-semibold leading-tight"
-            title={description || headerName}
-          >
-            {headerName}
-          </h3>
-          <p className="truncate text-xs text-muted-foreground">{headerTotal} 首</p>
-        </div>
-        {/* 操作按钮组：宽屏时 ml-auto 右对齐，窄屏 flex-wrap 后整组换到第二行 */}
-        <div className="ml-auto flex shrink-0 flex-wrap items-center gap-2">
-          {showActionDropdown ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button size="sm" disabled={allArchives.isLoading} className="shrink-0">
-                  <PlayCircle className="mr-1 h-4 w-4" />
-                  {playAllLabel}
-                  <ChevronDown className="ml-1 h-3 w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
+      )}
+      {archives.length > 0 && <ViewModeToggle value={favViewMode} onChange={setFavViewMode} />}
+
+      {/* 「播放合集」整合按钮：主体=播放整个合集；▾ 下拉分「播放」「加入歌单」两组 */}
+      <div className="inline-flex shrink-0">
+        <Button
+          size="sm"
+          onClick={isHighRisk ? handlePlayAllWithConfirm : handlePlayAll}
+          disabled={allArchives.isLoading}
+          className="rounded-r-none border-r-0"
+        >
+          <PlayCircle className="mr-1 h-4 w-4" />
+          {playAllLabel}
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              disabled={allArchives.isLoading}
+              className="rounded-l-none px-2"
+              aria-label="播放与加入歌单更多选项"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {showActionDropdown && (
+              <>
+                <DropdownMenuLabel>播放</DropdownMenuLabel>
                 {batches.map((b) => (
                   <DropdownMenuItem
-                    key={`${b.fromPage}-${b.toPage}`}
+                    key={`play-${b.fromPage}-${b.toPage}`}
                     onSelect={() => playRange({ fromPage: b.fromPage, toPage: b.toPage })}
                   >
                     <PlayCircle className="mr-2 h-4 w-4" />
@@ -501,90 +568,50 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
                   自定义范围…
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
+              </>
+            )}
+            {showActionDropdown && <DropdownMenuLabel>加入歌单</DropdownMenuLabel>}
+            <DropdownMenuItem onSelect={handleAddCurrentLoaded}>
+              <ListPlus className="mr-2 h-4 w-4" />
+              {addToFavLabel}
+            </DropdownMenuItem>
+            {showActionDropdown && (
+              <>
+                {batches.map((b) => (
+                  <DropdownMenuItem
+                    key={`add-${b.fromPage}-${b.toPage}`}
+                    onSelect={() => handleAddRange(b.fromPage, b.toPage)}
+                  >
+                    <ListPlus className="mr-2 h-4 w-4" />
+                    加入 {b.label}
+                  </DropdownMenuItem>
+                ))}
+                <DropdownMenuItem onSelect={() => setRangeDialog({ open: true, mode: 'add' })}>
+                  <ListPlus className="mr-2 h-4 w-4" />
+                  自定义范围…
+                </DropdownMenuItem>
                 <DropdownMenuItem
-                  onSelect={isHighRisk ? handlePlayAllWithConfirm : handlePlayAll}
+                  onSelect={isHighRisk ? handleAddAllConfirm : handleAddAllDirect}
                   className={isHighRisk ? 'text-destructive focus:text-destructive' : undefined}
                 >
-                  <PlayCircle className="mr-2 h-4 w-4" />
-                  全部 {headerTotal} 首{isHighRisk && '（高风险）'}
+                  <ListPlus className="mr-2 h-4 w-4" />
+                  全部 {headerTotal} 首加入歌单{isHighRisk && '（高风险）'}
                 </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <Button
-              size="sm"
-              onClick={handlePlayAll}
-              disabled={allArchives.isLoading}
-              className="shrink-0"
-            >
-              <PlayCircle className="mr-1 h-4 w-4" />
-              {playAllLabel}
-            </Button>
-          )}
-          {showActionDropdown ? (
-            // Split button：主按钮直接「加入当前已加载」；右侧 ▾ 展开范围 / 全部
-            <div className="inline-flex shrink-0">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleAddCurrentLoaded}
-                disabled={allArchives.isLoading}
-                className="rounded-r-none border-r-0"
-              >
-                <ListPlus className="mr-1 h-4 w-4" />
-                {addToFavLabel}
-              </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={allArchives.isLoading}
-                    className="rounded-l-none px-2"
-                    aria-label="加入歌单更多选项"
-                  >
-                    <ChevronDown className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {batches.map((b) => (
-                    <DropdownMenuItem
-                      key={`add-${b.fromPage}-${b.toPage}`}
-                      onSelect={() => handleAddRange(b.fromPage, b.toPage)}
-                    >
-                      <ListPlus className="mr-2 h-4 w-4" />
-                      加入 {b.label}
-                    </DropdownMenuItem>
-                  ))}
-                  <DropdownMenuItem onSelect={() => setRangeDialog({ open: true, mode: 'add' })}>
-                    <ListPlus className="mr-2 h-4 w-4" />
-                    自定义范围…
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onSelect={isHighRisk ? handleAddAllConfirm : handleAddAllDirect}
-                    className={isHighRisk ? 'text-destructive focus:text-destructive' : undefined}
-                  >
-                    <ListPlus className="mr-2 h-4 w-4" />
-                    全部 {headerTotal} 首{isHighRisk && '（高风险）'}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          ) : (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleAddCurrentLoaded}
-              disabled={allArchives.isLoading}
-              className="shrink-0"
-            >
-              <ListPlus className="mr-1 h-4 w-4" />
-              {addToFavLabel}
-            </Button>
-          )}
-        </div>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
+    </>
+  );
+
+  return (
+    <div className="flex flex-1 flex-col gap-3">
+      {headerSlot ? (
+        createPortal(headerContent, headerSlot)
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">{headerContent}</div>
+      )}
 
       {isLoading && archives.length === 0 ? (
         <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
@@ -594,9 +621,24 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
         <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
           合集是空的
         </div>
+      ) : filteredVisible.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
+          没有找到关键词为"{searchKey}"的结果
+        </div>
+      ) : favViewMode === 'thumbnail' ? (
+        <div className="grid grid-cols-2 gap-3 rounded-md border p-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+          {filteredVisible.map((video) => (
+            <ThumbnailGridCard
+              key={video.bvid}
+              video={video}
+              isPlaying={currentTrackId === video.bvid}
+              onClick={() => addSingle(video.bvid, true)}
+            />
+          ))}
+        </div>
       ) : (
         <div className="flex flex-col gap-1 rounded-md border p-2">
-          {visibleVideos.map((video) => (
+          {filteredVisible.map((video) => (
             <VideoItem
               key={video.bvid}
               video={video}
@@ -610,18 +652,13 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack }: SeasonDetailProp
       )}
 
       {totalPages > 1 && (
-        <>
-          <Pagination
-            page={page}
-            totalPages={totalPages}
-            hasMore={hasMore}
-            disabled={isLoading}
-            onChange={setPage}
-          />
-          <p className="text-center text-xs text-muted-foreground">
-            此处仅供浏览；批量播放 / 加入歌单请用上方按钮
-          </p>
-        </>
+        <Pagination
+          page={page}
+          totalPages={totalPages}
+          hasMore={hasMore}
+          disabled={isLoading}
+          onChange={setPage}
+        />
       )}
 
       <MediaLoadingDialog

--- a/packages/web/src/components/uploader-seasons-tab.tsx
+++ b/packages/web/src/components/uploader-seasons-tab.tsx
@@ -39,6 +39,7 @@ import { MediaLoadingDialog } from '@/components/dialogs/media-loading-dialog';
 import { PageRangeDialog } from '@/components/dialogs/page-range-dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -606,60 +607,75 @@ function SeasonDetail({ mid, opened, fallback, favId, onBack, headerSlot }: Seas
   );
 
   return (
-    <div className="flex flex-1 flex-col gap-3">
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
       {headerSlot ? (
         createPortal(headerContent, headerSlot)
       ) : (
         <div className="flex flex-wrap items-center gap-2">{headerContent}</div>
       )}
 
-      {isLoading && archives.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
-          加载中…
-        </div>
-      ) : archives.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
-          合集是空的
-        </div>
-      ) : filteredVisible.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center py-12 text-sm text-muted-foreground">
-          没有找到关键词为"{searchKey}"的结果
-        </div>
-      ) : favViewMode === 'thumbnail' ? (
-        <div className="grid grid-cols-2 gap-3 rounded-md border p-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {filteredVisible.map((video) => (
-            <ThumbnailGridCard
-              key={video.bvid}
-              video={video}
-              isPlaying={currentTrackId === video.bvid}
-              onClick={() => addSingle(video.bvid, true)}
-            />
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-col gap-1 rounded-md border p-2">
-          {filteredVisible.map((video) => (
-            <VideoItem
-              key={video.bvid}
-              video={video}
-              favId={favId}
-              fullCreateTime
-              showAddBtn
-              showAddToPlayBtn
-            />
-          ))}
-        </div>
-      )}
+      <div className="relative min-h-0 flex-1 overflow-hidden rounded-md border">
+        {isLoading && archives.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+            加载中…
+          </div>
+        ) : archives.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+            合集是空的
+          </div>
+        ) : filteredVisible.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+            没有找到关键词为"{searchKey}"的结果
+          </div>
+        ) : favViewMode === 'thumbnail' ? (
+          <div
+            className={cn(
+              'absolute inset-0 grid grid-cols-2 content-start gap-3 overflow-auto p-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5',
+              totalPages > 1 && 'pb-14',
+            )}
+          >
+            {filteredVisible.map((video) => (
+              <ThumbnailGridCard
+                key={video.bvid}
+                video={video}
+                isPlaying={currentTrackId === video.bvid}
+                onClick={() => addSingle(video.bvid, true)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div
+            className={cn(
+              'absolute inset-0 flex flex-col gap-1 overflow-auto p-2',
+              totalPages > 1 && 'pb-14',
+            )}
+          >
+            {filteredVisible.map((video) => (
+              <VideoItem
+                key={video.bvid}
+                video={video}
+                favId={favId}
+                fullCreateTime
+                showAddBtn
+                showAddToPlayBtn
+              />
+            ))}
+          </div>
+        )}
 
-      {totalPages > 1 && (
-        <Pagination
-          page={page}
-          totalPages={totalPages}
-          hasMore={hasMore}
-          disabled={isLoading}
-          onChange={setPage}
-        />
-      )}
+        {/* 底部浮层：分页栏叠在列表上方（半透明+模糊），列表滚动内容末尾留 pb-14 安全区避免被遮挡 */}
+        {totalPages > 1 && (
+          <div className="absolute inset-x-0 bottom-0 border-t bg-background/80 backdrop-blur-sm">
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              hasMore={hasMore}
+              disabled={isLoading}
+              onChange={setPage}
+            />
+          </div>
+        )}
+      </div>
 
       <MediaLoadingDialog
         loading={allArchives.isLoading}
@@ -692,29 +708,31 @@ interface PaginationProps {
 
 function Pagination({ page, totalPages, hasMore, disabled, onChange }: PaginationProps) {
   return (
-    <div className="flex items-center justify-center gap-2 py-2">
+    <div className="flex shrink-0 items-center justify-center gap-1.5 py-1">
       <Button
         variant="outline"
         size="sm"
+        className="h-8 gap-1 px-2.5 text-xs"
         onClick={() => onChange(page - 1)}
         disabled={disabled || page <= 1}
         aria-label="上一页"
       >
-        <ChevronLeft className="h-4 w-4" />
+        <ChevronLeft className="h-3.5 w-3.5" />
         上一页
       </Button>
-      <span className="px-2 text-xs text-muted-foreground">
+      <span className="px-1 text-xs text-muted-foreground">
         {page} / {totalPages}
       </span>
       <Button
         variant="outline"
         size="sm"
+        className="h-8 gap-1 px-2.5 text-xs"
         onClick={() => onChange(page + 1)}
         disabled={disabled || !hasMore}
         aria-label="下一页"
       >
         下一页
-        <ChevronRight className="h-4 w-4" />
+        <ChevronRight className="h-3.5 w-3.5" />
       </Button>
     </div>
   );

--- a/packages/web/src/components/video-thumbnail-grid.tsx
+++ b/packages/web/src/components/video-thumbnail-grid.tsx
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { BilibiliVideo } from '@shuoshuo-player/shared';
+import { ThumbnailGridCard } from './thumbnail-grid-card';
+
+/** 单卡最小理想宽度（px）：决定窄屏 2-3 列、宽屏 4-6 列的临界 */
+const MIN_CARD_WIDTH = 180;
+const MIN_COLS = 2;
+const MAX_COLS = 6;
+/** 列间距 / 行间距（px），对应 Tailwind gap-3 */
+const GAP = 12;
+const ROW_GAP = 12;
+/**
+ * 封面之外的卡片附加高度（px）：p-1 上下 8 + gap-1.5 6 + 标题 2 行(text-sm/leading-snug ≈ 38)。
+ * 用于由列宽推导行高；偏差只影响滚动条总长，不影响功能（见组件文档）。
+ */
+const CARD_META_HEIGHT = 52;
+
+export interface ThumbnailGridItem {
+  video: BilibiliVideo;
+  /** 用于 isPlaying 比对与播放：home 用纯 bvid，fav 用 trackId（可能含 :p<n>） */
+  trackId: string;
+  explicitPage?: number;
+}
+
+export interface VideoThumbnailGridProps {
+  items: ThumbnailGridItem[];
+  /** 当前播放 trackId，用于卡片高亮 */
+  currentTrackId?: string;
+  onItemClick: (item: ThumbnailGridItem) => void;
+}
+
+/**
+ * 3:2 缩略图网格，按「行」虚拟化以支撑上千条投稿。
+ *
+ * 难点：响应式列数与虚拟化协调。列数必须用 JS 实测容器宽推导（虚拟化要确切列数算行数），
+ * 不能只靠 CSS 断点。行高由列宽推导而非 measureElement —— 卡片封面 aspect-[3/2] + 标题
+ * line-clamp-2 高度恒定，固定 estimateSize 比逐行测量更稳（避免切列数 / 图片异步 load 抖动）。
+ */
+export function VideoThumbnailGrid({
+  items,
+  currentTrackId,
+  onItemClick,
+}: VideoThumbnailGridProps) {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      // 仅跨整数像素变化才 setState，避免亚像素抖动触发频繁重算
+      setContainerWidth((prev) => (Math.abs(prev - w) >= 1 ? w : prev));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const cols = useMemo(() => {
+    if (containerWidth <= 0) return MIN_COLS;
+    const raw = Math.floor((containerWidth + GAP) / (MIN_CARD_WIDTH + GAP));
+    return Math.min(MAX_COLS, Math.max(MIN_COLS, raw));
+  }, [containerWidth]);
+
+  const rowHeight = useMemo(() => {
+    const colWidth =
+      containerWidth > 0 ? (containerWidth - (cols - 1) * GAP) / cols : MIN_CARD_WIDTH;
+    return colWidth * (2 / 3) + CARD_META_HEIGHT + ROW_GAP;
+  }, [containerWidth, cols]);
+
+  const rowCount = Math.ceil(items.length / cols);
+
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => rowHeight,
+    // 行 overscan 比单列小：每行已含多卡，3 行足够预渲染
+    overscan: 3,
+  });
+
+  // 列数 / 行高变化后强制按新尺寸重算，否则窗口缩放后行位置错位（重叠或留白）
+  useEffect(() => {
+    virtualizer.measure();
+  }, [virtualizer, rowHeight, cols]);
+
+  const renderRow = useCallback(
+    (rowIndex: number) => {
+      const start = rowIndex * cols;
+      const rowItems = items.slice(start, start + cols);
+      return (
+        <div
+          className="grid"
+          style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`, gap: GAP }}
+        >
+          {rowItems.map((item) => (
+            <ThumbnailGridCard
+              key={item.trackId}
+              video={item.video}
+              explicitPage={item.explicitPage}
+              isPlaying={currentTrackId === item.trackId}
+              onClick={() => onItemClick(item)}
+            />
+          ))}
+        </div>
+      );
+    },
+    [items, cols, currentTrackId, onItemClick],
+  );
+
+  return (
+    <div
+      ref={parentRef}
+      className="min-h-0 flex-1 overflow-auto rounded-md border p-2"
+      style={{ contain: 'strict' }}
+    >
+      <div style={{ height: virtualizer.getTotalSize(), position: 'relative', width: '100%' }}>
+        {virtualizer.getVirtualItems().map((vr) => (
+          <div
+            key={vr.key}
+            data-index={vr.index}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${vr.start}px)`,
+            }}
+          >
+            {renderRow(vr.index)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/video-thumbnail-grid.tsx
+++ b/packages/web/src/components/video-thumbnail-grid.tsx
@@ -28,6 +28,8 @@ export interface VideoThumbnailGridProps {
   /** 当前播放 trackId，用于卡片高亮 */
   currentTrackId?: string;
   onItemClick: (item: ThumbnailGridItem) => void;
+  /** 存在则卡片右键菜单显示「移除歌曲」（仅歌单内传入） */
+  onItemRemove?: (item: ThumbnailGridItem) => void;
 }
 
 /**
@@ -41,6 +43,7 @@ export function VideoThumbnailGrid({
   items,
   currentTrackId,
   onItemClick,
+  onItemRemove,
 }: VideoThumbnailGridProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -100,12 +103,13 @@ export function VideoThumbnailGrid({
               explicitPage={item.explicitPage}
               isPlaying={currentTrackId === item.trackId}
               onClick={() => onItemClick(item)}
+              onRemove={onItemRemove ? () => onItemRemove(item) : undefined}
             />
           ))}
         </div>
       );
     },
-    [items, cols, currentTrackId, onItemClick],
+    [items, cols, currentTrackId, onItemClick, onItemRemove],
   );
 
   return (

--- a/packages/web/src/components/view-mode-toggle.test.tsx
+++ b/packages/web/src/components/view-mode-toggle.test.tsx
@@ -1,0 +1,25 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ViewModeToggle } from './view-mode-toggle';
+
+describe('ViewModeToggle', () => {
+  it('点击列表 / 缩略图按钮触发 onChange 对应枚举', () => {
+    const onChange = vi.fn();
+    render(<ViewModeToggle value="thumbnail" onChange={onChange} />);
+
+    fireEvent.click(screen.getByLabelText('列表视图'));
+    expect(onChange).toHaveBeenCalledWith('list');
+
+    fireEvent.click(screen.getByLabelText('缩略图视图'));
+    expect(onChange).toHaveBeenCalledWith('thumbnail');
+  });
+
+  it('aria-pressed 随 value 切换', () => {
+    const { rerender } = render(<ViewModeToggle value="list" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('列表视图')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByLabelText('缩略图视图')).toHaveAttribute('aria-pressed', 'false');
+
+    rerender(<ViewModeToggle value="thumbnail" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('列表视图')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByLabelText('缩略图视图')).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/packages/web/src/components/view-mode-toggle.tsx
+++ b/packages/web/src/components/view-mode-toggle.tsx
@@ -1,0 +1,41 @@
+import { List, LayoutGrid } from 'lucide-react';
+import type { VideoListViewMode } from '@shuoshuo-player/shared';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface ViewModeToggleProps {
+  value: VideoListViewMode;
+  onChange: (mode: VideoListViewMode) => void;
+  className?: string;
+}
+
+/** 列表 / 缩略图视图切换：两个相邻 icon 按钮，选中态用 secondary 高亮 */
+export function ViewModeToggle({ value, onChange, className }: ViewModeToggleProps) {
+  return (
+    <div
+      className={cn('inline-flex shrink-0 overflow-hidden rounded-md border', className)}
+      role="group"
+    >
+      <Button
+        variant={value === 'list' ? 'secondary' : 'ghost'}
+        size="icon"
+        className="h-9 w-9 rounded-none"
+        aria-label="列表视图"
+        aria-pressed={value === 'list'}
+        onClick={() => onChange('list')}
+      >
+        <List className="h-4 w-4" />
+      </Button>
+      <Button
+        variant={value === 'thumbnail' ? 'secondary' : 'ghost'}
+        size="icon"
+        className="h-9 w-9 rounded-none"
+        aria-label="缩略图视图"
+        aria-pressed={value === 'thumbnail'}
+        onClick={() => onChange('thumbnail')}
+      >
+        <LayoutGrid className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/use-video-item-actions.test.ts
+++ b/packages/web/src/hooks/use-video-item-actions.test.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react';
+import {
+  usePlayingListStore,
+  useUIStore,
+  useFavoritesStore,
+  useVideoPagePrefStore,
+  type BilibiliVideo,
+} from '@shuoshuo-player/shared';
+import { useUIShell } from '@/stores/ui-shell';
+import { useVideoItemActions } from './use-video-item-actions';
+
+function makeVideo(overrides: Partial<BilibiliVideo> = {}): BilibiliVideo {
+  return {
+    bvid: 'BV1',
+    title: 'Track',
+    videos: 1,
+    ...overrides,
+  } as BilibiliVideo;
+}
+
+describe('useVideoItemActions', () => {
+  let addSingle: ReturnType<typeof vi.fn>;
+  let openAddToFav: ReturnType<typeof vi.fn>;
+  let openPagesPicker: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    addSingle = vi.fn();
+    openAddToFav = vi.fn();
+    openPagesPicker = vi.fn();
+    useFavoritesStore.setState({ entries: {} });
+    useVideoPagePrefStore.setState({ defaultPage: {} });
+    usePlayingListStore.setState({ addSingle });
+    useUIStore.setState({ notices: [] });
+    useUIShell.setState({ openAddToFav, openPagesPicker });
+  });
+
+  it('toggleLike 切换收藏态', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo()));
+    expect(result.current.isFavored).toBe(false);
+    result.current.toggleLike();
+    expect('BV1' in useFavoritesStore.getState().entries).toBe(true);
+  });
+
+  it('addToPlay 调 addSingle(trackId, false)', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo()));
+    result.current.addToPlay();
+    expect(addSingle).toHaveBeenCalledWith('BV1', false);
+  });
+
+  it('addToPlay 对失效视频拦截，不调 addSingle', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo({ invalid: true })));
+    result.current.addToPlay();
+    expect(addSingle).not.toHaveBeenCalled();
+  });
+
+  it('addToFav 调 openAddToFav', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo()));
+    result.current.addToFav();
+    expect(openAddToFav).toHaveBeenCalledWith('BV1', { fromSearch: false });
+  });
+
+  it('openPagesPicker 调 useUIShell.openPagesPicker', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo({ videos: 3 })));
+    result.current.openPagesPicker();
+    expect(openPagesPicker).toHaveBeenCalledTimes(1);
+  });
+
+  it('pinDefaultPage 写入默认 P', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo({ videos: 3 })));
+    result.current.pinDefaultPage(2);
+    expect(useVideoPagePrefStore.getState().defaultPage['BV1']).toBe(2);
+  });
+
+  it('单 P 投稿 isMultiPart=false', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo({ videos: 1 })));
+    expect(result.current.isMultiPart).toBe(false);
+  });
+
+  it('多 P 投稿 isMultiPart=true 且 partItems 按 totalP 生成', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo({ videos: 3 })));
+    expect(result.current.isMultiPart).toBe(true);
+    expect(result.current.partItems).toHaveLength(3);
+  });
+
+  it('显式分 P 时 isMultiPart=false（已锁定 P）', () => {
+    const { result } = renderHook(() => useVideoItemActions(makeVideo({ videos: 3 }), 2));
+    expect(result.current.isMultiPart).toBe(false);
+    expect(result.current.effectiveTrackId).toBe('BV1:p2');
+  });
+});

--- a/packages/web/src/hooks/use-video-item-actions.ts
+++ b/packages/web/src/hooks/use-video-item-actions.ts
@@ -1,0 +1,127 @@
+import { useCallback, useMemo } from 'react';
+import {
+  usePlayingListStore,
+  useUIStore,
+  useFavoritesStore,
+  useVideoPagePrefStore,
+  buildTrackId,
+  getPlatformBridge,
+  NoticeType,
+  type BilibiliVideo,
+} from '@shuoshuo-player/shared';
+import { useUIShell } from '@/stores/ui-shell';
+
+export interface VideoItemPart {
+  key: string | number;
+  page: number;
+  part?: string;
+}
+
+export interface VideoItemActions {
+  effectiveTrackId: string;
+  isFavored: boolean;
+  /** 多 P 投稿且未锁定显式 P（分 P 相关操作的渲染条件） */
+  isMultiPart: boolean;
+  partItems: VideoItemPart[];
+  defaultPage: number;
+  toggleLike: () => void;
+  addToPlay: () => void;
+  addToFav: () => void;
+  openPagesPicker: () => void;
+  pinDefaultPage: (page: number) => void;
+  openBilibili: () => void;
+}
+
+/**
+ * 视频条目操作集（收藏 / 稍后播放 / 添加歌单 / 分 P / 去 B 站）。
+ *
+ * 抽出供缩略图右键菜单复用，逻辑与 VideoItem 内对应 handler 对齐（含 toast 文案与失效拦截）。
+ * VideoItem 暂未迁移到本 hook，两处逻辑短期并存——这是为隔离核心列表组件的回归风险，
+ * 后续可让 VideoItem 复用本 hook 消除重复。
+ */
+export function useVideoItemActions(video: BilibiliVideo, explicitPage?: number): VideoItemActions {
+  const addSingle = usePlayingListStore((s) => s.addSingle);
+  const sendNotice = useUIStore((s) => s.sendNotice);
+  const toggleFavorite = useFavoritesStore((s) => s.toggle);
+  const setDefaultPage = useVideoPagePrefStore((s) => s.setDefaultPage);
+  const openPagesPickerStore = useUIShell((s) => s.openPagesPicker);
+  const openAddToFavStore = useUIShell((s) => s.openAddToFav);
+
+  const effectiveTrackId = useMemo(
+    () => buildTrackId(video.bvid, explicitPage),
+    [video.bvid, explicitPage],
+  );
+  const isFavored = useFavoritesStore((s) => effectiveTrackId in s.entries);
+  const defaultPage = useVideoPagePrefStore((s) => s.defaultPage[video.bvid] ?? 1);
+
+  const totalP = video.videos ?? 1;
+  const isMultiPart = totalP > 1 && explicitPage === undefined;
+  const partItems = useMemo<VideoItemPart[]>(() => {
+    if (video.pages && video.pages.length > 0) {
+      return video.pages.map((p) => ({ key: p.cid, page: p.page, part: p.part }));
+    }
+    return Array.from({ length: totalP }, (_, i) => ({ key: i + 1, page: i + 1 }));
+  }, [video.pages, totalP]);
+
+  const isInvalid = video.invalid === true;
+
+  const toggleLike = useCallback(() => {
+    const nextFavored = toggleFavorite(effectiveTrackId);
+    sendNotice({
+      type: NoticeType.SUCCESS,
+      message: nextFavored ? '已添加到我的收藏' : '已从我的收藏移除',
+      duration: 2000,
+    });
+  }, [toggleFavorite, sendNotice, effectiveTrackId]);
+
+  const addToPlay = useCallback(() => {
+    if (isInvalid) {
+      sendNotice({
+        type: NoticeType.WARN,
+        message: '该视频已被作者删除或不可访问',
+        duration: 2500,
+      });
+      return;
+    }
+    addSingle(effectiveTrackId, false);
+    sendNotice({ type: NoticeType.SUCCESS, message: '添加成功', duration: 2000 });
+  }, [isInvalid, addSingle, sendNotice, effectiveTrackId]);
+
+  const addToFav = useCallback(() => {
+    openAddToFavStore(effectiveTrackId, { fromSearch: false });
+  }, [openAddToFavStore, effectiveTrackId]);
+
+  const openPagesPicker = useCallback(() => {
+    openPagesPickerStore(video);
+  }, [openPagesPickerStore, video]);
+
+  const pinDefaultPage = useCallback(
+    (page: number) => {
+      setDefaultPage(video.bvid, page);
+      sendNotice({
+        type: NoticeType.SUCCESS,
+        message: page <= 1 ? '已清除默认 P 设置' : `已设默认 P${page}`,
+        duration: 2000,
+      });
+    },
+    [setDefaultPage, sendNotice, video.bvid],
+  );
+
+  const openBilibili = useCallback(() => {
+    void getPlatformBridge().shell.openExternal(`https://www.bilibili.com/video/${video.bvid}`);
+  }, [video.bvid]);
+
+  return {
+    effectiveTrackId,
+    isFavored,
+    isMultiPart,
+    partItems,
+    defaultPage,
+    toggleLike,
+    addToPlay,
+    addToFav,
+    openPagesPicker,
+    pinDefaultPage,
+    openBilibili,
+  };
+}

--- a/packages/web/src/pages/fav-list.test.tsx
+++ b/packages/web/src/pages/fav-list.test.tsx
@@ -32,11 +32,13 @@ vi.mock('@/components/video-thumbnail-grid', () => ({
   VideoThumbnailGrid: ({
     items,
     onItemClick,
+    onItemRemove,
   }: {
     items: Array<{ video: { bvid: string; title: string }; trackId: string }>;
     onItemClick: (item: { trackId: string; video: { bvid: string } }) => void;
+    onItemRemove?: (item: { trackId: string }) => void;
   }) => (
-    <div data-testid="thumbnail-grid">
+    <div data-testid="thumbnail-grid" data-has-remove={onItemRemove ? 'yes' : 'no'}>
       {items.map((it) => (
         <div
           key={it.trackId}
@@ -313,5 +315,17 @@ describe('FavListPage', () => {
     const cards = screen.getAllByTestId('thumbnail-card');
     fireEvent.click(cards[0]);
     expect(addSingle).toHaveBeenCalledWith('BV1', true);
+  });
+
+  it('缩略图模式：CUSTOM 歌单向网格传入移除回调（卡片右键菜单可移除）', () => {
+    usePlayerProfileStore.setState({ favViewMode: 'thumbnail' });
+    useBilibiliVideosStore.setState({
+      ids: ['BV1'],
+      entities: { BV1: { bvid: 'BV1', title: 'Track A' } as never },
+    });
+    useFavListStore.setState({ list: [makeFav()] });
+
+    renderAt('fav-x');
+    expect(screen.getByTestId('thumbnail-grid')).toHaveAttribute('data-has-remove', 'yes');
   });
 });

--- a/packages/web/src/pages/fav-list.test.tsx
+++ b/packages/web/src/pages/fav-list.test.tsx
@@ -5,6 +5,8 @@ import {
   useBilibiliVideosStore,
   useFavListStore,
   useFavoritesStore,
+  usePlayerProfileStore,
+  usePlayingListStore,
   useUIStore,
   FavListType,
 } from '@shuoshuo-player/shared';
@@ -22,6 +24,29 @@ vi.mock('@/components/video-item', () => ({
   VideoItem: ({ video }: { video: { bvid: string; title: string } }) => (
     <div data-testid="video-item" data-bvid={video.bvid}>
       {video.title}
+    </div>
+  ),
+}));
+// 缩略图网格 mock：全量渲染卡片，规避真实虚拟化在 jsdom 下数量不稳定
+vi.mock('@/components/video-thumbnail-grid', () => ({
+  VideoThumbnailGrid: ({
+    items,
+    onItemClick,
+  }: {
+    items: Array<{ video: { bvid: string; title: string }; trackId: string }>;
+    onItemClick: (item: { trackId: string; video: { bvid: string } }) => void;
+  }) => (
+    <div data-testid="thumbnail-grid">
+      {items.map((it) => (
+        <div
+          key={it.trackId}
+          data-testid="thumbnail-card"
+          data-bvid={it.video.bvid}
+          onClick={() => onItemClick(it)}
+        >
+          {it.video.title}
+        </div>
+      ))}
     </div>
   ),
 }));
@@ -49,6 +74,8 @@ function reset() {
   useBilibiliVideosStore.setState({ ids: [], entities: {} });
   useUIStore.setState({ notices: [] });
   useFavoritesStore.setState({ entries: {} });
+  // 歌单视图模式默认 list；显式重置避免测试间污染
+  usePlayerProfileStore.setState({ favViewMode: 'list' });
 }
 
 function makeFav(overrides: Record<string, unknown> = {}) {
@@ -250,5 +277,41 @@ describe('FavListPage', () => {
 
     renderAt('b1');
     expect(screen.getByTestId('fav-card')).toBeInTheDocument();
+  });
+
+  it('缩略图模式渲染网格、列表项让位', () => {
+    usePlayerProfileStore.setState({ favViewMode: 'thumbnail' });
+    useBilibiliVideosStore.setState({
+      ids: ['BV1', 'BV2'],
+      entities: {
+        BV1: { bvid: 'BV1', title: 'Track A' } as never,
+        BV2: { bvid: 'BV2', title: 'Track B' } as never,
+      },
+    });
+    useFavListStore.setState({ list: [makeFav()] });
+
+    renderAt('fav-x');
+    expect(screen.getByTestId('thumbnail-grid')).toBeInTheDocument();
+    expect(screen.getAllByTestId('thumbnail-card')).toHaveLength(2);
+    expect(screen.queryByTestId('video-item')).not.toBeInTheDocument();
+  });
+
+  it('缩略图模式点击卡片调用 addSingle(trackId, true)', () => {
+    usePlayerProfileStore.setState({ favViewMode: 'thumbnail' });
+    const addSingle = vi.fn();
+    usePlayingListStore.setState({ addSingle });
+    useBilibiliVideosStore.setState({
+      ids: ['BV1', 'BV2'],
+      entities: {
+        BV1: { bvid: 'BV1', title: 'Track A' } as never,
+        BV2: { bvid: 'BV2', title: 'Track B' } as never,
+      },
+    });
+    useFavListStore.setState({ list: [makeFav()] });
+
+    renderAt('fav-x');
+    const cards = screen.getAllByTestId('thumbnail-card');
+    fireEvent.click(cards[0]);
+    expect(addSingle).toHaveBeenCalledWith('BV1', true);
   });
 });

--- a/packages/web/src/pages/fav-list.tsx
+++ b/packages/web/src/pages/fav-list.tsx
@@ -284,6 +284,7 @@ export function FavListPage() {
           items={thumbnailItems}
           currentTrackId={currentTrackId}
           onItemClick={handleThumbnailClick}
+          onItemRemove={isTypeCustom ? (item) => handleRemoveSong(item.trackId) : undefined}
         />
       ) : (
         <div

--- a/packages/web/src/pages/fav-list.tsx
+++ b/packages/web/src/pages/fav-list.tsx
@@ -71,6 +71,8 @@ export function FavListPage() {
   const [searchKey, setSearchKey] = useState('');
   const [favoritesOrder, setFavoritesOrder] = useState<FavoritesOrder>('desc');
   const parentRef = useRef<HTMLDivElement>(null);
+  // 合集详情 header 通过 Portal 提到 Tab 行，与「视频投稿/合集」Tab 合并成一行；此为 portal 目标容器
+  const [seasonHeaderSlot, setSeasonHeaderSlot] = useState<HTMLDivElement | null>(null);
 
   const favList = useFavListStore((s) => s.list);
   const removeFavVideo = useFavListStore((s) => s.removeFavVideo);
@@ -218,119 +220,127 @@ export function FavListPage() {
     );
   }
 
-  /* "视频投稿"区块（搜索栏 + 列表/空态），单独抽取以便 UPLOADER 类型嵌入 Tab、其他类型直接渲染 */
-  const videosSection: ReactNode = (
-    <>
-      {favVideoList.length > 0 && (
-        <div className="flex items-center gap-2">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="搜索歌曲（标题 / 作者 / 简介）"
-              value={searchKey}
-              onChange={(e) => setSearchKey(e.target.value)}
-              className="pl-9"
-            />
-            {searchKey && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2"
-                onClick={() => setSearchKey('')}
-              >
-                <X className="h-3 w-3" />
-              </Button>
-            )}
-          </div>
-          {isFavoritesPage && (
+  /* 搜索栏内容（搜索框 + 排序 + 视图切换 + 命中）：UPLOADER 与 Tabs 合并一行，其他类型独立成行 */
+  const searchBarContent: ReactNode =
+    favVideoList.length > 0 ? (
+      <>
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="搜索歌曲（标题 / 作者 / 简介）"
+            value={searchKey}
+            onChange={(e) => setSearchKey(e.target.value)}
+            className="pl-9"
+          />
+          {searchKey && (
             <Button
-              variant="outline"
-              size="sm"
-              className="h-9 shrink-0 gap-1"
-              onClick={() => setFavoritesOrder((o) => (o === 'desc' ? 'asc' : 'desc'))}
+              variant="ghost"
+              size="icon"
+              className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2"
+              onClick={() => setSearchKey('')}
             >
-              {favoritesOrder === 'desc' ? (
-                <ArrowDownNarrowWide className="h-3.5 w-3.5" />
-              ) : (
-                <ArrowUpNarrowWide className="h-3.5 w-3.5" />
-              )}
-              {favoritesOrder === 'desc' ? '最新收藏在前' : '最早收藏在前'}
+              <X className="h-3 w-3" />
             </Button>
           )}
-          <ViewModeToggle value={favViewMode} onChange={setFavViewMode} />
-          {searchKey && (
-            <span className="text-xs text-muted-foreground">
-              命中 {filteredVideos.length} / {favVideoList.length}
-            </span>
-          )}
         </div>
-      )}
-      {filteredVideos.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
-          {searchKey ? (
-            <>
-              <AlertCircle className="h-6 w-6" />
-              没有找到关键词为"{searchKey}"的结果
-            </>
-          ) : (
-            <>
-              <FolderOpen className="h-6 w-6" />
-              {favVideoList.length === 0 ? '歌单是空的' : '没有可显示的视频'}
-            </>
-          )}
-        </div>
-      ) : favViewMode === 'thumbnail' ? (
-        <VideoThumbnailGrid
-          items={thumbnailItems}
-          currentTrackId={currentTrackId}
-          onItemClick={handleThumbnailClick}
-          onItemRemove={isTypeCustom ? (item) => handleRemoveSong(item.trackId) : undefined}
-        />
-      ) : (
-        <div
-          ref={parentRef}
-          className="flex-1 overflow-auto rounded-md border"
-          style={{ contain: 'strict' }}
-        >
-          <div
-            style={{
-              height: virtualizer.getTotalSize(),
-              position: 'relative',
-              width: '100%',
-            }}
+        {isFavoritesPage && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-9 shrink-0 gap-1"
+            onClick={() => setFavoritesOrder((o) => (o === 'desc' ? 'asc' : 'desc'))}
           >
-            {virtualizer.getVirtualItems().map((virtualRow) => {
-              const row = filteredVideos[virtualRow.index];
-              return (
-                <div
-                  key={virtualRow.key}
-                  data-index={virtualRow.index}
-                  ref={virtualizer.measureElement}
-                  style={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: '100%',
-                    transform: `translateY(${virtualRow.start}px)`,
-                  }}
-                >
-                  <div className="px-2 py-1">
-                    <VideoItem
-                      video={row.video}
-                      explicitPage={row.explicitPage}
-                      favId={favId}
-                      fullCreateTime
-                      showAuthor={isTypeCustom}
-                      showRemoveBtn={isTypeCustom}
-                      onRemove={() => handleRemoveSong(row.trackId)}
-                    />
-                  </div>
+            {favoritesOrder === 'desc' ? (
+              <ArrowDownNarrowWide className="h-3.5 w-3.5" />
+            ) : (
+              <ArrowUpNarrowWide className="h-3.5 w-3.5" />
+            )}
+            {favoritesOrder === 'desc' ? '最新收藏在前' : '最早收藏在前'}
+          </Button>
+        )}
+        <ViewModeToggle value={favViewMode} onChange={setFavViewMode} />
+        {searchKey && (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            命中 {filteredVideos.length} / {favVideoList.length}
+          </span>
+        )}
+      </>
+    ) : null;
+
+  /* 列表/空态区块（list 虚拟滚动 或 thumbnail 网格） */
+  const listSection: ReactNode =
+    filteredVideos.length === 0 ? (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+        {searchKey ? (
+          <>
+            <AlertCircle className="h-6 w-6" />
+            没有找到关键词为"{searchKey}"的结果
+          </>
+        ) : (
+          <>
+            <FolderOpen className="h-6 w-6" />
+            {favVideoList.length === 0 ? '歌单是空的' : '没有可显示的视频'}
+          </>
+        )}
+      </div>
+    ) : favViewMode === 'thumbnail' ? (
+      <VideoThumbnailGrid
+        items={thumbnailItems}
+        currentTrackId={currentTrackId}
+        onItemClick={handleThumbnailClick}
+        onItemRemove={isTypeCustom ? (item) => handleRemoveSong(item.trackId) : undefined}
+      />
+    ) : (
+      <div
+        ref={parentRef}
+        className="flex-1 overflow-auto rounded-md border"
+        style={{ contain: 'strict' }}
+      >
+        <div
+          style={{
+            height: virtualizer.getTotalSize(),
+            position: 'relative',
+            width: '100%',
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const row = filteredVideos[virtualRow.index];
+            return (
+              <div
+                key={virtualRow.key}
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              >
+                <div className="px-2 py-1">
+                  <VideoItem
+                    video={row.video}
+                    explicitPage={row.explicitPage}
+                    favId={favId}
+                    fullCreateTime
+                    showAuthor={isTypeCustom}
+                    showRemoveBtn={isTypeCustom}
+                    onRemove={() => handleRemoveSong(row.trackId)}
+                  />
                 </div>
-              );
-            })}
-          </div>
+              </div>
+            );
+          })}
         </div>
-      )}
+      </div>
+    );
+
+  /* 非 UPLOADER 类型：搜索行（独立成行）+ 列表 */
+  const videosSection: ReactNode = (
+    <>
+      {searchBarContent && <div className="flex items-center gap-2">{searchBarContent}</div>}
+      {listSection}
     </>
   );
 
@@ -361,10 +371,24 @@ export function FavListPage() {
           onValueChange={handleTabChange}
           className="flex min-h-0 flex-1 flex-col gap-4"
         >
-          <TabsList className="w-fit">
-            <TabsTrigger value="videos">视频投稿</TabsTrigger>
-            <TabsTrigger value="seasons">合集</TabsTrigger>
-          </TabsList>
+          {/*
+           * Tab 与右侧内容合并一行：
+           *   视频投稿 Tab → 右侧搜索栏；合集 Tab → 右侧是 SeasonDetail 经 Portal 提上来的合集详情 header。
+           * flex-wrap 让窄屏（扩展弹窗 ~400px）下右侧内容回落到第二行。
+           */}
+          <div className="flex flex-wrap items-center gap-2">
+            <TabsList className="w-fit shrink-0">
+              <TabsTrigger value="videos">视频投稿</TabsTrigger>
+              <TabsTrigger value="seasons">合集</TabsTrigger>
+            </TabsList>
+            {tab === 'videos' && searchBarContent}
+            {tab === 'seasons' && (
+              <div
+                ref={setSeasonHeaderSlot}
+                className="flex min-w-0 flex-1 flex-wrap items-center gap-2"
+              />
+            )}
+          </div>
           {/*
            * forceMount 让两个 Tab 内容常驻 DOM（仅由 CSS hidden 控制显隐）。
            * 默认行为下 Radix Tabs.Content 在 inactive 时会 unmount，导致：
@@ -376,14 +400,14 @@ export function FavListPage() {
             forceMount
             className="mt-0 flex min-h-0 flex-1 flex-col gap-4 data-[state=inactive]:hidden"
           >
-            {videosSection}
+            {listSection}
           </TabsContent>
           <TabsContent
             value="seasons"
             forceMount
             className="mt-0 flex min-h-0 flex-1 flex-col data-[state=inactive]:hidden"
           >
-            <UploaderSeasonsTab mid={uploaderMid} favId={favId} />
+            <UploaderSeasonsTab mid={uploaderMid} favId={favId} headerSlot={seasonHeaderSlot} />
           </TabsContent>
         </Tabs>
       ) : (

--- a/packages/web/src/pages/fav-list.tsx
+++ b/packages/web/src/pages/fav-list.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Fuse from 'fuse.js';
@@ -17,6 +17,8 @@ import {
   useBilibiliVideosStore,
   useFavListStore,
   useFavoritesStore,
+  usePlayerProfileStore,
+  usePlayingListStore,
   useUIStore,
   selectSortedBvids,
   parseTrackId,
@@ -27,6 +29,8 @@ import {
 } from '@shuoshuo-player/shared';
 import { useUIShell } from '@/stores/ui-shell';
 import { VideoItem } from '@/components/video-item';
+import { ViewModeToggle } from '@/components/view-mode-toggle';
+import { VideoThumbnailGrid, type ThumbnailGridItem } from '@/components/video-thumbnail-grid';
 import { FavCard } from '@/components/fav-card';
 import { UploaderSeasonsTab } from '@/components/uploader-seasons-tab';
 import { Input } from '@/components/ui/input';
@@ -79,6 +83,10 @@ export function FavListPage() {
 
   const sendNotice = useUIStore((s) => s.sendNotice);
   const openConfirm = useUIShell((s) => s.openConfirm);
+
+  const favViewMode = usePlayerProfileStore((s) => s.favViewMode);
+  const setFavViewMode = usePlayerProfileStore((s) => s.setFavViewMode);
+  const currentTrackId = usePlayingListStore((s) => s.current);
 
   // 切换 favId 时清空搜索框
   useEffect(() => {
@@ -167,6 +175,22 @@ export function FavListPage() {
     overscan: 5,
   });
 
+  // 缩略图网格条目（保留 trackId 与 explicitPage：CUSTOM/favorites 条目可能含 :p<n>）
+  const thumbnailItems = useMemo<ThumbnailGridItem[]>(
+    () =>
+      filteredVideos.map((r) => ({
+        video: r.video,
+        trackId: r.trackId,
+        explicitPage: r.explicitPage,
+      })),
+    [filteredVideos],
+  );
+
+  // 点击缩略图：复用 VideoItem 同款语义——favId 存在时 addSingle 加载整张歌单并播放该条
+  const handleThumbnailClick = useCallback((item: ThumbnailGridItem) => {
+    usePlayingListStore.getState().addSingle(item.trackId, true);
+  }, []);
+
   const handleRemoveSong = (trackId: string) => {
     if (!isTypeCustom) return;
     const isFav = isFavoritesPage;
@@ -233,6 +257,7 @@ export function FavListPage() {
               {favoritesOrder === 'desc' ? '最新收藏在前' : '最早收藏在前'}
             </Button>
           )}
+          <ViewModeToggle value={favViewMode} onChange={setFavViewMode} />
           {searchKey && (
             <span className="text-xs text-muted-foreground">
               命中 {filteredVideos.length} / {favVideoList.length}
@@ -254,6 +279,12 @@ export function FavListPage() {
             </>
           )}
         </div>
+      ) : favViewMode === 'thumbnail' ? (
+        <VideoThumbnailGrid
+          items={thumbnailItems}
+          currentTrackId={currentTrackId}
+          onItemClick={handleThumbnailClick}
+        />
       ) : (
         <div
           ref={parentRef}

--- a/packages/web/src/pages/home.test.tsx
+++ b/packages/web/src/pages/home.test.tsx
@@ -177,7 +177,7 @@ describe('HomePage', () => {
     expect(screen.getByText('视频 0')).toBeInTheDocument();
   });
 
-  it('Carousel 显示前 5 条 + 点击 slide 触发 setPlaylist', () => {
+  it('Carousel 显示前 10 条 + 点击 slide 触发 setPlaylist', () => {
     const { entities, list } = makeVideoEntries(10);
     useBilibiliVideosStore.setState({ ids: Object.keys(entities), entities });
     useBilibiliUserVideosStore.setState({
@@ -195,7 +195,7 @@ describe('HomePage', () => {
 
     renderHome();
     const slides = screen.getAllByTestId('carousel-slide');
-    expect(slides).toHaveLength(5);
+    expect(slides).toHaveLength(10);
 
     fireEvent.click(slides[2]);
 

--- a/packages/web/src/pages/home.test.tsx
+++ b/packages/web/src/pages/home.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, waitFor, act } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import {
   MASTER_UP_INFO,
   useBilibiliUserVideosStore,
   useBilibiliVideosStore,
+  usePlayerProfileStore,
   usePlayingListStore,
   useUIStore,
 } from '@shuoshuo-player/shared';
@@ -61,6 +62,29 @@ vi.mock('@/components/carousel', () => ({
     </div>
   ),
 }));
+// 缩略图网格 mock：全量渲染卡片，规避真实虚拟化在 jsdom 下数量不稳定
+vi.mock('@/components/video-thumbnail-grid', () => ({
+  VideoThumbnailGrid: ({
+    items,
+    onItemClick,
+  }: {
+    items: Array<{ video: { bvid: string; title: string }; trackId: string }>;
+    onItemClick: (item: { trackId: string; video: { bvid: string } }) => void;
+  }) => (
+    <div data-testid="thumbnail-grid">
+      {items.map((it) => (
+        <div
+          key={it.trackId}
+          data-testid="thumbnail-card"
+          data-bvid={it.video.bvid}
+          onClick={() => onItemClick(it)}
+        >
+          {it.video.title}
+        </div>
+      ))}
+    </div>
+  ),
+}));
 
 const MASTER_MID = String(MASTER_UP_INFO.mid);
 
@@ -74,6 +98,8 @@ function reset() {
   useBilibiliVideosStore.setState({ ids: [], entities: {} });
   usePlayingListStore.setState({ favId: '', trackIds: [], current: '', playNext: false });
   useUIStore.setState({ notices: [] });
+  // 视图模式默认值（首页 thumbnail）；显式重置避免测试间污染
+  usePlayerProfileStore.setState({ homeViewMode: 'thumbnail' });
 }
 
 function makeVideoEntries(count: number) {
@@ -153,7 +179,7 @@ describe('HomePage', () => {
     expect(screen.getByText('最新投稿')).toBeInTheDocument();
   });
 
-  it('全量视频走虚拟滚动渲染（不再硬限 30 条）', () => {
+  it('默认缩略图模式：网格渲染全部投稿（不再硬限 30 条）', () => {
     const { entities, list } = makeVideoEntries(35);
     useBilibiliVideosStore.setState({ ids: Object.keys(entities), entities });
     useBilibiliUserVideosStore.setState({
@@ -170,11 +196,68 @@ describe('HomePage', () => {
     });
 
     renderHome();
-    // jsdom 下虚拟滚动基于 ResizeObserver mock，渲染数量不稳定；
-    // 关键验证：① 容器存在 ② 最新一条（最靠前）会出现在初始可视区
-    const items = screen.queryAllByTestId('video-item');
-    expect(items.length).toBeGreaterThanOrEqual(0);
-    expect(screen.getByText('视频 0')).toBeInTheDocument();
+    // 默认 thumbnail：网格（mock）全量渲染 35 条，不渲染列表项
+    const cards = screen.getAllByTestId('thumbnail-card');
+    expect(cards).toHaveLength(35);
+    expect(cards[0]).toHaveAttribute('data-bvid', 'BV0000000000');
+    expect(screen.queryByTestId('video-item')).not.toBeInTheDocument();
+  });
+
+  it('切换到列表模式时网格让位给 VideoItem 列表', () => {
+    usePlayerProfileStore.setState({ homeViewMode: 'list' });
+    const { entities, list } = makeVideoEntries(5);
+    useBilibiliVideosStore.setState({ ids: Object.keys(entities), entities });
+    useBilibiliUserVideosStore.setState({
+      infos: {
+        [MASTER_MID]: {
+          update_time: Math.floor(Date.now() / 1000),
+          video_list: list,
+          count: 5,
+          update_type: 'default',
+        } as never,
+      },
+      readUserVideos: vi.fn(),
+      readUserSpaceInfo: vi.fn(),
+    });
+
+    renderHome();
+    // 列表模式不渲染缩略图网格（VideoItem 数量受 jsdom 虚拟滚动影响，不强断言）
+    expect(screen.queryByTestId('thumbnail-grid')).not.toBeInTheDocument();
+  });
+
+  it('点击视图切换按钮更新 homeViewMode 偏好', () => {
+    renderHome();
+    expect(usePlayerProfileStore.getState().homeViewMode).toBe('thumbnail');
+    fireEvent.click(screen.getByLabelText('列表视图'));
+    expect(usePlayerProfileStore.getState().homeViewMode).toBe('list');
+    fireEvent.click(screen.getByLabelText('缩略图视图'));
+    expect(usePlayerProfileStore.getState().homeViewMode).toBe('thumbnail');
+  });
+
+  it('点击缩略图卡片：替换队列为全量投稿并播放该条', () => {
+    const { entities, list } = makeVideoEntries(10);
+    useBilibiliVideosStore.setState({ ids: Object.keys(entities), entities });
+    useBilibiliUserVideosStore.setState({
+      infos: {
+        [MASTER_MID]: {
+          update_time: Math.floor(Date.now() / 1000),
+          video_list: list,
+          count: 10,
+          update_type: 'default',
+        } as never,
+      },
+      readUserVideos: vi.fn(),
+      readUserSpaceInfo: vi.fn(),
+    });
+
+    renderHome();
+    const cards = screen.getAllByTestId('thumbnail-card');
+    fireEvent.click(cards[2]);
+    const state = usePlayingListStore.getState();
+    expect(state.favId).toBe('main');
+    expect(state.trackIds).toHaveLength(10);
+    expect(state.current).toBe('BV0000000002');
+    expect(state.playNext).toBe(true);
   });
 
   it('Carousel 显示前 10 条 + 点击 slide 触发 setPlaylist', () => {

--- a/packages/web/src/pages/home.test.tsx
+++ b/packages/web/src/pages/home.test.tsx
@@ -167,7 +167,7 @@ describe('HomePage', () => {
     expect(readUserVideos).not.toHaveBeenCalled();
   });
 
-  it('显示空间名（spaceInfo.name）作为标题副文本', () => {
+  it('渲染「最新投稿」标题，不再显示 UP 主空间名副文本', () => {
     useBilibiliUserVideosStore.setState({
       space: { [MASTER_MID]: { name: '说说Crystal' } as never },
       readUserVideos: vi.fn(async () => {}),
@@ -175,8 +175,8 @@ describe('HomePage', () => {
     });
 
     renderHome();
-    expect(screen.getByText('说说Crystal')).toBeInTheDocument();
     expect(screen.getByText('最新投稿')).toBeInTheDocument();
+    expect(screen.queryByText('说说Crystal')).not.toBeInTheDocument();
   });
 
   it('默认缩略图模式：网格渲染全部投稿（不再硬限 30 条）', () => {

--- a/packages/web/src/pages/home.tsx
+++ b/packages/web/src/pages/home.tsx
@@ -7,6 +7,7 @@ import {
   useBilibiliUserVideosStore,
   useBilibiliVideosStore,
   usePlayingListStore,
+  usePlayerProfileStore,
   useUIStore,
   timeStampNow,
   urlPrefixFixed,
@@ -15,6 +16,8 @@ import {
 } from '@shuoshuo-player/shared';
 import { VideoItem } from '@/components/video-item';
 import { Carousel } from '@/components/carousel';
+import { ViewModeToggle } from '@/components/view-mode-toggle';
+import { VideoThumbnailGrid, type ThumbnailGridItem } from '@/components/video-thumbnail-grid';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import {
@@ -43,6 +46,9 @@ export function HomePage() {
 
   const videoEntities = useBilibiliVideosStore((s) => s.entities);
   const setPlaylist = usePlayingListStore((s) => s.setPlaylist);
+  const currentTrackId = usePlayingListStore((s) => s.current);
+  const homeViewMode = usePlayerProfileStore((s) => s.homeViewMode);
+  const setHomeViewMode = usePlayerProfileStore((s) => s.setHomeViewMode);
   const loaded = useBilibiliUserVideosStore((s) => s.loaded);
   const progressTotal = useBilibiliUserVideosStore((s) => s.progressTotal);
   const cancelRefresh = useBilibiliUserVideosStore((s) => s.cancelRefresh);
@@ -94,6 +100,21 @@ export function HomePage() {
     const trackIds = allVideos.map((v) => v.bvid);
     setPlaylist(MAIN_FAV_ID, trackIds, video.bvid, true);
   };
+
+  // 缩略图网格条目（home 用纯 bvid 作 trackId）
+  const thumbnailItems = useMemo<ThumbnailGridItem[]>(
+    () => allVideos.map((v) => ({ video: v, trackId: v.bvid })),
+    [allVideos],
+  );
+
+  // 点击缩略图：与轮播点击同款——替换播放队列为全量投稿并立即播放该条
+  const handleThumbnailClick = useCallback(
+    (item: ThumbnailGridItem) => {
+      const trackIds = allVideos.map((v) => v.bvid);
+      setPlaylist(MAIN_FAV_ID, trackIds, item.video.bvid, true);
+    },
+    [allVideos, setPlaylist],
+  );
 
   const handleOpenRangeDialog = useCallback(() => {
     if (sourceTotal === 0) {
@@ -166,63 +187,72 @@ export function HomePage() {
           <h2 className="text-lg font-semibold">最新投稿</h2>
           {spaceInfo?.name && <p className="text-xs text-muted-foreground">{spaceInfo.name}</p>}
         </div>
-        <div className="inline-flex shrink-0">
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={isLoading}
-            onClick={() => void readUserVideos(MASTER_MID, 'incremental')}
-            className="rounded-r-none border-r-0"
-          >
-            {isLoading ? (
-              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-1 h-4 w-4" />
-            )}
-            检查更新
-          </Button>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="sm"
-                variant="outline"
-                disabled={isLoading}
-                className="rounded-l-none px-2"
-                aria-label="更多刷新选项"
-              >
-                <ChevronDown className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="min-w-[180px]">
-              <DropdownMenuItem
-                onSelect={() => void readUserVideos(MASTER_MID, 'incremental')}
-                disabled={isLoading}
-              >
-                <RefreshCw className="mr-2 h-4 w-4" />
-                检查更新
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={handleOpenRangeDialog} disabled={isLoading}>
-                <Sliders className="mr-2 h-4 w-4" />
-                按范围拉取…
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={handleFullyReload}
-                disabled={isLoading}
-                className="text-destructive focus:text-destructive"
-              >
-                <AlertTriangle className="mr-2 h-4 w-4" />
-                重新拉取全部
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+        <div className="flex shrink-0 items-center gap-2">
+          <ViewModeToggle value={homeViewMode} onChange={setHomeViewMode} />
+          <div className="inline-flex">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isLoading}
+              onClick={() => void readUserVideos(MASTER_MID, 'incremental')}
+              className="rounded-r-none border-r-0"
+            >
+              {isLoading ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-1 h-4 w-4" />
+              )}
+              检查更新
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={isLoading}
+                  className="rounded-l-none px-2"
+                  aria-label="更多刷新选项"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[180px]">
+                <DropdownMenuItem
+                  onSelect={() => void readUserVideos(MASTER_MID, 'incremental')}
+                  disabled={isLoading}
+                >
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  检查更新
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={handleOpenRangeDialog} disabled={isLoading}>
+                  <Sliders className="mr-2 h-4 w-4" />
+                  按范围拉取…
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={handleFullyReload}
+                  disabled={isLoading}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <AlertTriangle className="mr-2 h-4 w-4" />
+                  重新拉取全部
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       </div>
 
-      {/* 视频列表区：全量虚拟滚动；列表区独占剩余高度，顶部轮播+标题保持固定 */}
+      {/* 视频列表区：列表模式虚拟滚动 / 缩略图模式网格；顶部轮播+标题保持固定 */}
       {allVideos.length === 0 ? (
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           {isLoading ? '正在拉取最新投稿…' : '暂无视频，请点击「检查更新」'}
         </div>
+      ) : homeViewMode === 'thumbnail' ? (
+        <VideoThumbnailGrid
+          items={thumbnailItems}
+          currentTrackId={currentTrackId}
+          onItemClick={handleThumbnailClick}
+        />
       ) : (
         <div
           ref={parentRef}

--- a/packages/web/src/pages/home.tsx
+++ b/packages/web/src/pages/home.tsx
@@ -15,6 +15,7 @@ import {
 } from '@shuoshuo-player/shared';
 import { VideoItem } from '@/components/video-item';
 import { Carousel } from '@/components/carousel';
+import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -57,8 +58,8 @@ export function HomePage() {
     return list.map((it) => videoEntities[it.bvid]).filter((v): v is BilibiliVideo => Boolean(v));
   }, [videoListInfo, videoEntities]);
 
-  // 顶部轮播：最新 5 条（按 created 倒序）
-  const carouselSlides = useMemo(() => allVideos.slice(0, 5), [allVideos]);
+  // 顶部轮播：最新 10 条（按 created 倒序）
+  const carouselSlides = useMemo(() => allVideos.slice(0, 10), [allVideos]);
 
   // 范围拉取所需总页数（B 站接口 count 字段）
   const sourceTotal = videoListInfo?.count ?? 0;
@@ -134,9 +135,16 @@ export function HomePage() {
             slides={carouselSlides}
             autoplayDelay={4000}
             loop
+            align="center"
+            slideClassName="flex-[0_0_auto] px-1.5"
             onSlideClick={handleSlideClick}
-            renderSlide={(video) => (
-              <div className="relative h-56 w-full overflow-hidden rounded-md sm:h-64">
+            renderSlide={(video, _index, isSelected) => (
+              <div
+                className={cn(
+                  'relative aspect-video h-44 overflow-hidden rounded-xl transition-all duration-300 sm:h-56',
+                  isSelected ? 'opacity-100 shadow-lg' : 'opacity-55',
+                )}
+              >
                 <img
                   src={urlPrefixFixed(video.pic)}
                   alt={video.title}

--- a/packages/web/src/pages/home.tsx
+++ b/packages/web/src/pages/home.tsx
@@ -183,10 +183,7 @@ export function HomePage() {
 
       {/* 标题 + split button（主键直点 incremental，▾ 展开范围/全部） */}
       <div className="flex shrink-0 items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">最新投稿</h2>
-          {spaceInfo?.name && <p className="text-xs text-muted-foreground">{spaceInfo.name}</p>}
-        </div>
+        <h2 className="text-lg font-semibold">最新投稿</h2>
         <div className="flex shrink-0 items-center gap-2">
           <ViewModeToggle value={homeViewMode} onChange={setHomeViewMode} />
           <div className="inline-flex">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.16
+        version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -846,6 +849,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -3729,6 +3745,20 @@ snapshots:
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## 概述

本批改动集中在 **Web / Chrome 扩展端的 UI 体验改进** 与 **桌面端（Tauri）的安全/文案细节**，共 8 个提交。

## 桌面端 (Tauri)

- **B 站 cookie 落盘改为 XOR + base64 混淆存储**，避免明文落盘；命中旧明文时自动迁移（固定密钥以保持跨机可移植）。
- **macOS 托盘曲目文案截断到 15 字形**，按 Unicode 码点安全切割，不会切坏 emoji / 组合字符。

## Web / Chrome 扩展

- **首页轮播**改为居中焦点 16:9 卡片，并扩展至 10 条。
- **列表 / 缩略图视图切换**（缩略图为 3:2 宽裁切）：首页默认缩略图、歌单默认列表，记忆用户偏好并在无记忆时 fallback。
- **缩略图卡片右键菜单**：收藏 / 稍后播放 / 添加到歌单 / 选择分P / 记住默认P / 去 B 站 / 移除（仅歌单内）。
- 首页移除「最新投稿」标题下的 UP 主空间名小字。
- **UP 主歌单「合集」Tab 与合集详情头部合并为一行**（详情头部经 Portal 提到 Tab 行）；原「以合集为歌单播放」+「加入歌单」两个按钮整合为单个「播放合集」下拉按钮。
- **合集详情**支持页内搜索（标题/作者，过滤当前页）+ 列表/缩略图视图切换。
- **合集详情列表拉满剩余高度**，分页改为底部毛玻璃浮层、并在滚动内容末尾留出安全区，避免最后一条被遮挡。

## 测试与质量

- 全套件通过：shared 485 + web 602 + desktop 100。
- typecheck（shared/web/desktop）、lint（0 error）通过。
- Chrome 扩展构建成功，体积 1417 KiB（预算 10240 KiB）。